### PR TITLE
Add Terraform configuration for GCP VM bootstrap

### DIFF
--- a/bootstrap/terraform.tfvars.example
+++ b/bootstrap/terraform.tfvars.example
@@ -1,0 +1,48 @@
+# Agentium Bootstrap Terraform Variables Example
+#
+# Copy this file to terraform.tfvars and fill in your values:
+#   cp terraform.tfvars.example terraform.tfvars
+
+# =============================================================================
+# Required Variables
+# =============================================================================
+
+# GCP project ID
+project_id = "my-gcp-project"
+
+# Target GitHub repository (owner/repo format)
+repository = "andymwolf/agentium"
+
+# Issue number(s) to work on (comma-separated)
+issues = "42"
+
+# GitHub App credentials
+github_app_id             = "123456"
+github_installation_id    = "789012"
+github_private_key_secret = "github-app-key"
+
+# =============================================================================
+# Optional Variables (uncomment to override defaults)
+# =============================================================================
+
+# GCP region and zone
+# region = "us-central1"
+# zone   = "us-central1-a"
+
+# GCP network (defaults to "default")
+# network = "default"
+
+# Machine type (defaults to "e2-medium")
+# machine_type = "e2-medium"
+
+# Boot disk size in GB (defaults to 50)
+# boot_disk_size_gb = 50
+
+# Maximum session duration in hours (defaults to 2, max 24)
+# max_session_hours = 2
+
+# Anthropic API key secret (optional - can also use ANTHROPIC_API_KEY env var)
+# anthropic_api_key_secret = "anthropic-api-key"
+
+# Custom session ID (auto-generated if not provided)
+# session_id = "my-custom-session"

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -12,11 +12,21 @@ variable "project_id" {
 variable "repository" {
   description = "Target GitHub repository (owner/repo format)"
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$", var.repository))
+    error_message = "Repository must be in owner/repo format (e.g., 'andymwolf/agentium')."
+  }
 }
 
 variable "issues" {
   description = "Comma-separated list of issue numbers to work on"
   type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]+(,[0-9]+)*$", var.issues))
+    error_message = "Issues must be comma-separated numbers (e.g., '42' or '42,43,44')."
+  }
 }
 
 variable "github_app_id" {
@@ -50,6 +60,12 @@ variable "zone" {
   default     = "us-central1-a"
 }
 
+variable "network" {
+  description = "GCP network to use for the VM"
+  type        = string
+  default     = "default"
+}
+
 variable "machine_type" {
   description = "GCP machine type for the VM"
   type        = string
@@ -75,13 +91,12 @@ variable "anthropic_api_key_secret" {
 }
 
 variable "max_session_hours" {
-  description = "Maximum session duration in hours before auto-cleanup"
+  description = "Maximum session duration in hours (VM auto-terminates after this)"
   type        = number
   default     = 2
-}
 
-variable "enable_auto_cleanup" {
-  description = "Enable automatic cleanup of the VM after max_session_hours"
-  type        = bool
-  default     = true
+  validation {
+    condition     = var.max_session_hours >= 1 && var.max_session_hours <= 24
+    error_message = "Max session hours must be between 1 and 24."
+  }
 }


### PR DESCRIPTION
## Summary
- Creates `bootstrap/main.tf` with GCP VM configuration
- Creates `bootstrap/variables.tf` with required and optional variables

## Features
- **Preemptible/Spot instances**: Uses spot VMs for significant cost savings
- **Service account**: Auto-creates service account with Secret Manager access
- **Instance metadata**: Session config (repo, issues, credentials) passed via metadata
- **50GB SSD**: Fast boot disk for quick startup
- **Auto-cleanup**: Optional Cloud Scheduler job to delete VM after max session time
- **Outputs**: Provides SSH command, logs command, and destroy command

## Required Variables
| Variable | Description |
|----------|-------------|
| `project_id` | GCP project ID |
| `repository` | Target GitHub repo (owner/repo) |
| `issues` | Comma-separated issue numbers |
| `github_app_id` | GitHub App ID |
| `github_installation_id` | Installation ID |
| `github_private_key_secret` | Secret Manager secret name |

## Test Plan
- [ ] Review Terraform syntax (`terraform validate`)
- [ ] Review variable definitions
- [ ] Test `terraform plan` with sample values
- [ ] Deploy test VM and verify metadata is passed correctly

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)