### PR TITLE
Add local launch script for bootstrap sessions

### DIFF
--- a/bootstrap/run.sh
+++ b/bootstrap/run.sh
@@ -197,6 +197,12 @@ validate_prerequisites() {
         exit 1
     fi
 
+    # Check jq (used for parsing Terraform outputs)
+    if ! command -v jq &> /dev/null; then
+        print_error "jq is not installed"
+        exit 1
+    fi
+
     # Check gcloud auth
     if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" &> /dev/null; then
         print_error "gcloud is not authenticated. Run 'gcloud auth login'"


### PR DESCRIPTION
## Summary
- Creates `bootstrap/run.sh` for launching Agentium sessions from your local machine

## Features
- **User-friendly CLI**: Clear flags and help documentation
- **Prerequisite checking**: Validates gcloud auth and terraform installation
- **Environment variables**: Support for setting credentials via env vars
- **Log following**: `--follow` flag to tail session logs after VM starts
- **Destroy mode**: Clean up resources with `--destroy`
- **Colored output**: Easy to read status messages

## Usage Examples
```bash
# Launch a session
./run.sh --repo andymwolf/agentium --issue 42

# Launch and follow logs
./run.sh --repo andymwolf/agentium --issue 42 --follow

# Work on multiple issues
./run.sh --repo andymwolf/agentium --issue 42,43,44

# With all options
./run.sh \
  --repo andymwolf/agentium \
  --issue 42 \
  --project my-gcp-project \
  --app-id 123456 \
  --installation-id 789012 \
  --private-key-secret github-app-key \
  --follow

# Destroy the session
./run.sh --destroy
```

## Environment Variables
| Variable | Description |
|----------|-------------|
| `AGENTIUM_PROJECT_ID` | GCP project ID |
| `AGENTIUM_GITHUB_APP_ID` | GitHub App ID |
| `AGENTIUM_GITHUB_INSTALLATION_ID` | Installation ID |
| `AGENTIUM_GITHUB_PRIVATE_KEY_SECRET` | Secret Manager secret name |

## Test Plan
- [ ] Review script for proper error handling
- [ ] Test prerequisite validation
- [ ] Test with valid credentials
- [ ] Verify log following works

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)