### PR TITLE
Add PR review support to agentium run command

### DIFF
--- a/bootstrap/SYSTEM.md
+++ b/bootstrap/SYSTEM.md
@@ -176,3 +176,40 @@ If this is not your first iteration (`AGENTIUM_ITERATION > 1`):
 - Review previous work and continue from where you left off
 - Check if PRs were created in previous iterations
 - Do not duplicate work already completed
+
+## PR REVIEW SESSIONS
+
+When working on a PR (vs. an issue), you are addressing code review feedback.
+The prompt will indicate if this is a PR review session.
+
+### Key Differences from Issue Sessions
+
+1. **You are already on the PR branch** - Do NOT create a new branch
+2. **Do NOT close the PR** - Just push your changes
+3. **Focus on review feedback** - Address what reviewers asked for
+4. **No PR creation needed** - The PR already exists
+
+### PR Review Workflow
+
+1. Read and understand the review comments provided in your prompt
+2. Make targeted changes to address the specific feedback
+3. Run tests to verify your changes work correctly
+4. Commit with a descriptive message (e.g., "Address review feedback: fix error handling")
+5. Push to the PR branch: `git push origin HEAD`
+
+### PR Review - DO NOT
+
+- Create a new branch (you're already on the PR branch)
+- Close or merge the PR (leave that for human reviewers)
+- Dismiss reviews
+- Force push (unless absolutely necessary to fix history)
+- Make unrelated changes beyond what reviewers requested
+
+### PR Review Completion
+
+A PR review session is complete when you have:
+1. Addressed all review feedback
+2. Verified tests pass
+3. Pushed your changes to the PR branch
+
+The session will automatically detect the push and consider your work complete.

--- a/bootstrap/cloud-init.yaml
+++ b/bootstrap/cloud-init.yaml
@@ -138,9 +138,16 @@ runcmd:
       export GITHUB_PRIVATE_KEY_SECRET=$(fetch_metadata "github-private-key-secret")
       export ANTHROPIC_API_KEY_SECRET=$(fetch_metadata "anthropic-api-key-secret")
 
-      # Validate required metadata
-      if [ -z "$AGENTIUM_REPOSITORY" ] || [ -z "$AGENTIUM_ISSUES" ]; then
-        echo "ERROR: Missing required metadata (repository or issues)" >> /var/log/agentium-init.log
+      # Fetch PR metadata (optional, for PR review sessions)
+      export AGENTIUM_PRS=$(fetch_metadata "agentium-prs" 2>/dev/null || echo "")
+
+      # Validate required metadata - need repository and at least issues or PRs
+      if [ -z "$AGENTIUM_REPOSITORY" ]; then
+        echo "ERROR: Missing required metadata (repository)" >> /var/log/agentium-init.log
+        exit 1
+      fi
+      if [ -z "$AGENTIUM_ISSUES" ] && [ -z "$AGENTIUM_PRS" ]; then
+        echo "ERROR: Missing required metadata (at least issues or prs required)" >> /var/log/agentium-init.log
         exit 1
       fi
 
@@ -158,7 +165,8 @@ runcmd:
         HOME="/home/agentium" \
         AGENTIUM_SESSION_ID="$AGENTIUM_SESSION_ID" \
         AGENTIUM_REPOSITORY="$AGENTIUM_REPOSITORY" \
-        AGENTIUM_ISSUES="$AGENTIUM_ISSUES" \
+        AGENTIUM_ISSUES="${AGENTIUM_ISSUES:-}" \
+        AGENTIUM_PRS="${AGENTIUM_PRS:-}" \
         GITHUB_APP_ID="$GITHUB_APP_ID" \
         GITHUB_INSTALLATION_ID="$GITHUB_INSTALLATION_ID" \
         GITHUB_PRIVATE_KEY_SECRET="$GITHUB_PRIVATE_KEY_SECRET" \

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -25,7 +25,7 @@ provider "google" {
 
 # Generate unique session ID if not provided
 resource "random_id" "session" {
-  byte_length = 6  # 12 hex chars to stay within GCP naming limits
+  byte_length = 6 # 12 hex chars to stay within GCP naming limits
 }
 
 locals {
@@ -113,14 +113,15 @@ resource "google_compute_instance" "agentium" {
     user-data = data.local_file.cloud_init.content
 
     # Agentium session configuration
-    agentium-autostart           = "true"
-    agentium-session-id          = local.session_id
-    agentium-repository          = var.repository
-    agentium-issues              = var.issues
-    github-app-id                = var.github_app_id
-    github-installation-id       = var.github_installation_id
-    github-private-key-secret    = var.github_private_key_secret
-    anthropic-api-key-secret     = var.anthropic_api_key_secret
+    agentium-autostart        = "true"
+    agentium-session-id       = local.session_id
+    agentium-repository       = var.repository
+    agentium-issues           = var.issues
+    agentium-prs              = var.prs
+    github-app-id             = var.github_app_id
+    github-installation-id    = var.github_installation_id
+    github-private-key-secret = var.github_private_key_secret
+    anthropic-api-key-secret  = var.anthropic_api_key_secret
   }
 
   # Labels for tracking

--- a/bootstrap/session.sh
+++ b/bootstrap/session.sh
@@ -7,10 +7,13 @@
 # Required environment variables:
 #   AGENTIUM_SESSION_ID      - Unique session identifier
 #   AGENTIUM_REPOSITORY      - Target repository (owner/repo format)
-#   AGENTIUM_ISSUES          - Comma-separated list of issue numbers
+#   AGENTIUM_ISSUES          - Comma-separated list of issue numbers (for issue sessions)
+#   AGENTIUM_PRS             - Comma-separated list of PR numbers (for PR review sessions)
 #   GITHUB_APP_ID            - GitHub App ID for authentication
 #   GITHUB_INSTALLATION_ID   - GitHub App installation ID
 #   GITHUB_PRIVATE_KEY_SECRET - GCP Secret Manager path for private key
+#
+# Note: At least one of AGENTIUM_ISSUES or AGENTIUM_PRS must be provided.
 #
 # Optional environment variables:
 #   AGENTIUM_MAX_ITERATIONS  - Maximum iterations (default: 5)
@@ -143,6 +146,123 @@ build_prompt() {
     echo -e "${prompt}"
 }
 
+# Fetch PR details from GitHub
+fetch_pr_details() {
+    local repo="$1"
+    local pr_number="$2"
+
+    gh pr view "${pr_number}" --repo "${repo}" \
+        --json number,title,body,headRefName
+}
+
+# Fetch PR review comments
+fetch_pr_reviews() {
+    local repo="$1"
+    local pr_number="$2"
+
+    gh api "repos/${repo}/pulls/${pr_number}/reviews" \
+        --jq '[.[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {state: .state, body: .body}]' 2>/dev/null || echo "[]"
+}
+
+# Fetch PR inline comments
+fetch_pr_comments() {
+    local repo="$1"
+    local pr_number="$2"
+
+    gh api "repos/${repo}/pulls/${pr_number}/comments" \
+        --jq '[.[] | {path: .path, line: .line, body: .body}]' 2>/dev/null || echo "[]"
+}
+
+# Build the prompt for PR review sessions
+build_pr_prompt() {
+    local repo="$1"
+    local prs="$2"
+
+    local prompt="You are working on repository: ${repo}\n\n"
+    prompt+="## PR REVIEW SESSION\n\n"
+    prompt+="You are addressing code review feedback on existing pull request(s).\n\n"
+
+    IFS=',' read -ra PR_ARRAY <<< "${prs}"
+    for pr_num in "${PR_ARRAY[@]}"; do
+        pr_num=$(echo "${pr_num}" | tr -d ' ')
+        local pr_json=$(fetch_pr_details "${repo}" "${pr_num}" 2>/dev/null || echo '{}')
+
+        if [[ "${pr_json}" != "{}" ]]; then
+            local title=$(echo "${pr_json}" | jq -r '.title // "Unknown"')
+            local branch=$(echo "${pr_json}" | jq -r '.headRefName // "unknown"')
+
+            prompt+="### PR #${pr_num}: ${title}\n"
+            prompt+="Branch: ${branch}\n\n"
+
+            # Fetch and add review comments
+            local reviews=$(fetch_pr_reviews "${repo}" "${pr_num}")
+            if [[ "${reviews}" != "[]" ]] && [[ -n "${reviews}" ]]; then
+                prompt+="**Review Feedback:**\n"
+                prompt+=$(echo "${reviews}" | jq -r '.[] | "- [\(.state)] \(.body)"' | head -c 1000)
+                prompt+="\n\n"
+            fi
+
+            # Fetch and add inline comments
+            local comments=$(fetch_pr_comments "${repo}" "${pr_num}")
+            if [[ "${comments}" != "[]" ]] && [[ -n "${comments}" ]]; then
+                prompt+="**Inline Comments:**\n"
+                prompt+=$(echo "${comments}" | jq -r '.[] | "- File: \(.path) (line \(.line))\n  Comment: \(.body)"' | head -c 1500)
+                prompt+="\n\n"
+            fi
+        else
+            prompt+="### PR #${pr_num}\n\n"
+        fi
+    done
+
+    prompt+="## Instructions\n\n"
+    prompt+="1. You are ALREADY on the PR branch - do NOT create a new branch\n"
+    prompt+="2. Read and understand the review comments\n"
+    prompt+="3. Make targeted changes to address the feedback\n"
+    prompt+="4. Run tests to verify your changes\n"
+    prompt+="5. Commit with message: \"Address review feedback\"\n"
+    prompt+="6. Push your changes: \`git push origin HEAD\`\n\n"
+    prompt+="## DO NOT\n\n"
+    prompt+="- Create a new branch (you're already on the PR branch)\n"
+    prompt+="- Close or merge the PR\n"
+    prompt+="- Dismiss reviews\n"
+    prompt+="- Force push (unless absolutely necessary)\n"
+    prompt+="- Make unrelated changes\n"
+
+    echo -e "${prompt}"
+}
+
+# Checkout PR branch
+checkout_pr_branch() {
+    local repo="$1"
+    local pr_number="$2"
+
+    local pr_json=$(fetch_pr_details "${repo}" "${pr_number}" 2>/dev/null || echo '{}')
+    if [[ "${pr_json}" == "{}" ]]; then
+        log_error "Failed to fetch PR #${pr_number} details"
+        return 1
+    fi
+
+    local branch=$(echo "${pr_json}" | jq -r '.headRefName')
+    if [[ -z "${branch}" ]] || [[ "${branch}" == "null" ]]; then
+        log_error "Failed to get branch name for PR #${pr_number}"
+        return 1
+    fi
+
+    log_info "Checking out PR branch: ${branch}"
+    git fetch origin "${branch}" 2>/dev/null || true
+    git checkout "${branch}"
+}
+
+# Detect if changes were pushed (for PR completion detection)
+detect_push_completion() {
+    local output="$1"
+    # Look for git push success pattern
+    if echo "${output}" | grep -qE 'To (github\.com|git@github\.com).*\n.*[a-f0-9]+\.\.[a-f0-9]+'; then
+        return 0
+    fi
+    return 1
+}
+
 # Fetch SYSTEM.md from agentium repository
 fetch_system_md() {
     local output_path="/tmp/SYSTEM.md"
@@ -198,12 +318,22 @@ run_claude() {
 main() {
     log_info "Starting Agentium session: ${AGENTIUM_SESSION_ID:-unknown}"
     log_info "Repository: ${AGENTIUM_REPOSITORY}"
-    log_info "Issues: ${AGENTIUM_ISSUES}"
+    if [[ -n "${AGENTIUM_ISSUES:-}" ]]; then
+        log_info "Issues: ${AGENTIUM_ISSUES}"
+    fi
+    if [[ -n "${AGENTIUM_PRS:-}" ]]; then
+        log_info "PRs: ${AGENTIUM_PRS}"
+    fi
 
     # Validate required environment variables
     : "${AGENTIUM_SESSION_ID:?AGENTIUM_SESSION_ID is required}"
     : "${AGENTIUM_REPOSITORY:?AGENTIUM_REPOSITORY is required}"
-    : "${AGENTIUM_ISSUES:?AGENTIUM_ISSUES is required}"
+
+    # Require at least issues or PRs
+    if [[ -z "${AGENTIUM_ISSUES:-}" ]] && [[ -z "${AGENTIUM_PRS:-}" ]]; then
+        log_error "At least one of AGENTIUM_ISSUES or AGENTIUM_PRS is required"
+        exit 1
+    fi
 
     # Get GitHub token
     local github_token=""
@@ -240,9 +370,6 @@ main() {
     # Create workspace
     mkdir -p "${WORKSPACE}"
 
-    # Clone repository
-    clone_repository "${AGENTIUM_REPOSITORY}" "${github_token}" "${AGENTIUM_BRANCH:-main}"
-
     # Fetch SYSTEM.md
     local system_md=$(fetch_system_md)
     if [[ -z "${system_md}" ]]; then
@@ -250,39 +377,75 @@ main() {
         exit 1
     fi
 
-    # Build prompt with issue context
-    local prompt=$(build_prompt "${AGENTIUM_REPOSITORY}" "${AGENTIUM_ISSUES}")
-
-    # Run iterations
     local max_iterations="${AGENTIUM_MAX_ITERATIONS:-5}"
     local iteration=1
+    local prompt=""
+    local is_pr_session=false
 
+    # Determine session type and set up accordingly
+    if [[ -n "${AGENTIUM_PRS:-}" ]]; then
+        is_pr_session=true
+        log_info "PR Review Session Mode"
+
+        # Clone repository (to main first, then checkout PR branch)
+        clone_repository "${AGENTIUM_REPOSITORY}" "${github_token}" "${AGENTIUM_BRANCH:-main}"
+
+        # Checkout the first PR's branch
+        IFS=',' read -ra PR_ARRAY <<< "${AGENTIUM_PRS}"
+        local first_pr=$(echo "${PR_ARRAY[0]}" | tr -d ' ')
+        checkout_pr_branch "${AGENTIUM_REPOSITORY}" "${first_pr}"
+
+        # Build PR-specific prompt
+        prompt=$(build_pr_prompt "${AGENTIUM_REPOSITORY}" "${AGENTIUM_PRS}")
+    else
+        log_info "Issue Session Mode"
+
+        # Clone repository
+        clone_repository "${AGENTIUM_REPOSITORY}" "${github_token}" "${AGENTIUM_BRANCH:-main}"
+
+        # Build prompt with issue context
+        prompt=$(build_prompt "${AGENTIUM_REPOSITORY}" "${AGENTIUM_ISSUES}")
+    fi
+
+    # Run iterations
     while [[ ${iteration} -le ${max_iterations} ]]; do
         log_info "=== Iteration ${iteration}/${max_iterations} ==="
 
-        if run_claude "${prompt}" "${system_md}" "${iteration}"; then
+        local output_file=$(mktemp)
+        if run_claude "${prompt}" "${system_md}" "${iteration}" 2>&1 | tee "${output_file}"; then
             log_info "Iteration ${iteration} completed successfully"
         else
             log_error "Iteration ${iteration} failed"
         fi
 
-        # Check if PRs were created for any of the target issues
-        # Look for PRs that reference "Closes #N" for our target issues
-        local pr_found=false
-        IFS=',' read -ra ISSUE_ARRAY <<< "${AGENTIUM_ISSUES}"
-        for issue_num in "${ISSUE_ARRAY[@]}"; do
-            issue_num=$(echo "${issue_num}" | tr -d ' ')
-            # Search for PRs that mention closing this issue
-            local pr_for_issue=$(gh pr list --repo "${AGENTIUM_REPOSITORY}" --state open \
-                --search "Closes #${issue_num} in:body" --json number 2>/dev/null | jq '. | length')
-            if [[ ${pr_for_issue} -gt 0 ]]; then
-                log_info "PR found for issue #${issue_num}, session complete"
-                pr_found=true
+        local output=$(cat "${output_file}")
+        rm -f "${output_file}"
+
+        # Check completion based on session type
+        if [[ "${is_pr_session}" == "true" ]]; then
+            # For PR sessions: detect if changes were pushed
+            if echo "${output}" | grep -qE 'To (github\.com|git@github\.com)'; then
+                log_info "Changes pushed to PR branch, session complete"
                 break
             fi
-        done
-        if [[ "${pr_found}" == "true" ]]; then
-            break
+        else
+            # For issue sessions: check if PRs were created
+            local pr_found=false
+            IFS=',' read -ra ISSUE_ARRAY <<< "${AGENTIUM_ISSUES}"
+            for issue_num in "${ISSUE_ARRAY[@]}"; do
+                issue_num=$(echo "${issue_num}" | tr -d ' ')
+                # Search for PRs that mention closing this issue
+                local pr_for_issue=$(gh pr list --repo "${AGENTIUM_REPOSITORY}" --state open \
+                    --search "Closes #${issue_num} in:body" --json number 2>/dev/null | jq '. | length')
+                if [[ ${pr_for_issue} -gt 0 ]]; then
+                    log_info "PR found for issue #${issue_num}, session complete"
+                    pr_found=true
+                    break
+                fi
+            done
+            if [[ "${pr_found}" == "true" ]]; then
+                break
+            fi
         fi
 
         ((iteration++))

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -32,6 +32,17 @@ variable "issues" {
   }
 }
 
+variable "prs" {
+  description = "Comma-separated list of PR numbers to address review feedback"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.prs == "" || can(regex("^[0-9]+(,[0-9]+)*$", var.prs))
+    error_message = "PRs must be comma-separated numbers (e.g., '42' or '42,43,44')."
+  }
+}
+
 variable "github_app_id" {
   description = "GitHub App ID for authentication"
   type        = string

--- a/internal/agent/claudecode/adapter.go
+++ b/internal/agent/claudecode/adapter.go
@@ -146,6 +146,13 @@ func (a *Adapter) ParseOutput(exitCode int, stdout, stderr string) (*agent.Itera
 		}
 	}
 
+	// Detect successful git push (for PR review sessions)
+	// Matches patterns like: "To github.com:owner/repo.git" followed by commit hash range
+	pushPattern := regexp.MustCompile(`To (?:github\.com|git@github\.com)[^\n]*\n.*[a-f0-9]+\.\.[a-f0-9]+`)
+	if pushPattern.MatchString(stdout + stderr) {
+		result.PushedChanges = true
+	}
+
 	// Extract error messages
 	if exitCode != 0 {
 		// Look for common error patterns

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -5,6 +5,7 @@ type Session struct {
 	ID            string
 	Repository    string
 	Tasks         []string
+	PRs           []string // PR numbers for review sessions
 	WorkDir       string
 	GitHubToken   string
 	MaxIterations int
@@ -19,6 +20,7 @@ type IterationResult struct {
 	Success        bool
 	TasksCompleted []string
 	PRsCreated     []string
+	PushedChanges  bool // True if git push was detected (for PR review sessions)
 	Error          string
 	Summary        string
 	TokensUsed     int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,6 +51,7 @@ type DefaultsConfig struct {
 type SessionConfig struct {
 	Repository    string   `mapstructure:"repository"`
 	Tasks         []string `mapstructure:"tasks"`
+	PRs           []string `mapstructure:"prs"`
 	Agent         string   `mapstructure:"agent"`
 	MaxIterations int      `mapstructure:"max_iterations"`
 	MaxDuration   string   `mapstructure:"max_duration"`
@@ -168,8 +169,8 @@ func (c *Config) ValidateForRun() error {
 		return fmt.Errorf("repository is required")
 	}
 
-	if len(c.Session.Tasks) == 0 {
-		return fmt.Errorf("at least one task/issue is required")
+	if len(c.Session.Tasks) == 0 && len(c.Session.PRs) == 0 {
+		return fmt.Errorf("at least one issue or PR is required")
 	}
 
 	if c.GitHub.AppID == 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -213,7 +213,7 @@ func TestConfig_ValidateForRun(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "at least one task/issue is required",
+			errMsg:  "at least one issue or PR is required",
 		},
 		{
 			name: "missing GitHub App ID",

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -22,6 +22,7 @@ type SessionConfig struct {
 	ID            string   `json:"id"`
 	Repository    string   `json:"repository"`
 	Tasks         []string `json:"tasks"`
+	PRs           []string `json:"prs,omitempty"`
 	Agent         string   `json:"agent"`
 	MaxIterations int      `json:"max_iterations"`
 	MaxDuration   string   `json:"max_duration"`
@@ -77,15 +78,16 @@ func LoadConfigFromEnv(getenv func(string) string, readFile func(string) ([]byte
 
 // Controller manages the agent execution lifecycle
 type Controller struct {
-	config       SessionConfig
-	agent        agent.Agent
-	workDir      string
-	iteration    int
-	startTime    time.Time
-	maxDuration  time.Duration
-	gitHubToken  string
-	completed    map[string]bool
-	logger       *log.Logger
+	config        SessionConfig
+	agent         agent.Agent
+	workDir       string
+	iteration     int
+	startTime     time.Time
+	maxDuration   time.Duration
+	gitHubToken   string
+	completed     map[string]bool
+	pushedChanges bool // Tracks if changes were pushed (for PR review sessions)
+	logger        *log.Logger
 }
 
 // New creates a new session controller
@@ -118,7 +120,12 @@ func (c *Controller) Run(ctx context.Context) error {
 	c.startTime = time.Now()
 	c.logger.Printf("Starting session %s", c.config.ID)
 	c.logger.Printf("Repository: %s", c.config.Repository)
-	c.logger.Printf("Tasks: %v", c.config.Tasks)
+	if len(c.config.Tasks) > 0 {
+		c.logger.Printf("Tasks: %v", c.config.Tasks)
+	}
+	if len(c.config.PRs) > 0 {
+		c.logger.Printf("PRs: %v", c.config.PRs)
+	}
 	c.logger.Printf("Agent: %s", c.config.Agent)
 	c.logger.Printf("Max iterations: %d", c.config.MaxIterations)
 	c.logger.Printf("Max duration: %s", c.maxDuration)
@@ -138,15 +145,29 @@ func (c *Controller) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to clone repository: %w", err)
 	}
 
-	// Fetch issue details
-	issues, err := c.fetchIssueDetails(ctx)
-	if err != nil {
-		c.logger.Printf("Warning: failed to fetch issue details: %v", err)
-	}
+	// Handle PR mode vs issue mode
+	if len(c.config.PRs) > 0 {
+		// PR review session: fetch PR details and checkout PR branch
+		prDetails, err := c.fetchPRDetails(ctx)
+		if err != nil {
+			c.logger.Printf("Warning: failed to fetch PR details: %v", err)
+		}
 
-	// Build initial prompt with issue context
-	if len(issues) > 0 {
-		c.config.Prompt = c.buildPromptWithIssues(issues)
+		// Build PR-specific prompt
+		if len(prDetails) > 0 {
+			c.config.Prompt = c.buildPromptWithPRs(prDetails)
+		}
+	} else {
+		// Issue session: fetch issue details
+		issues, err := c.fetchIssueDetails(ctx)
+		if err != nil {
+			c.logger.Printf("Warning: failed to fetch issue details: %v", err)
+		}
+
+		// Build initial prompt with issue context
+		if len(issues) > 0 {
+			c.config.Prompt = c.buildPromptWithIssues(issues)
+		}
 	}
 
 	// Main execution loop
@@ -181,9 +202,15 @@ func (c *Controller) Run(ctx context.Context) error {
 			c.completed[task] = true
 		}
 
-		// Check PRs created
+		// Check PRs created (for issue sessions)
 		if len(result.PRsCreated) > 0 {
 			c.logger.Printf("PRs created: %v", result.PRsCreated)
+		}
+
+		// Check if changes were pushed (for PR review sessions)
+		if result.PushedChanges {
+			c.pushedChanges = true
+			c.logger.Println("Changes pushed to PR branch")
 		}
 	}
 
@@ -311,6 +338,25 @@ type issueDetail struct {
 	Body   string `json:"body"`
 }
 
+type prDetail struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	Body        string `json:"body"`
+	HeadRefName string `json:"headRefName"`
+}
+
+type prReview struct {
+	State string `json:"state"`
+	Body  string `json:"body"`
+}
+
+type prComment struct {
+	Path     string `json:"path"`
+	Line     int    `json:"line"`
+	Body     string `json:"body"`
+	DiffHunk string `json:"diffHunk"`
+}
+
 func (c *Controller) fetchIssueDetails(ctx context.Context) ([]issueDetail, error) {
 	c.logger.Println("Fetching issue details")
 
@@ -340,6 +386,148 @@ func (c *Controller) fetchIssueDetails(ctx context.Context) ([]issueDetail, erro
 	}
 
 	return issues, nil
+}
+
+type prWithReviews struct {
+	Detail   prDetail
+	Reviews  []prReview
+	Comments []prComment
+}
+
+func (c *Controller) fetchPRDetails(ctx context.Context) ([]prWithReviews, error) {
+	c.logger.Println("Fetching PR details")
+
+	prs := make([]prWithReviews, 0, len(c.config.PRs))
+
+	for _, prNumber := range c.config.PRs {
+		// Fetch basic PR info
+		cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber,
+			"--repo", c.config.Repository,
+			"--json", "number,title,body,headRefName",
+		)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("GITHUB_TOKEN=%s", c.gitHubToken))
+
+		output, err := cmd.Output()
+		if err != nil {
+			c.logger.Printf("Warning: failed to fetch PR #%s: %v", prNumber, err)
+			continue
+		}
+
+		var pr prDetail
+		if err := json.Unmarshal(output, &pr); err != nil {
+			c.logger.Printf("Warning: failed to parse PR #%s: %v", prNumber, err)
+			continue
+		}
+
+		prWithRev := prWithReviews{Detail: pr}
+
+		// Checkout PR branch
+		c.logger.Printf("Checking out PR branch: %s", pr.HeadRefName)
+		checkoutCmd := exec.CommandContext(ctx, "git", "checkout", pr.HeadRefName)
+		checkoutCmd.Dir = c.workDir
+		if err := checkoutCmd.Run(); err != nil {
+			// Try fetching and checking out
+			fetchCmd := exec.CommandContext(ctx, "git", "fetch", "origin", pr.HeadRefName)
+			fetchCmd.Dir = c.workDir
+			fetchCmd.Run()
+			checkoutCmd = exec.CommandContext(ctx, "git", "checkout", pr.HeadRefName)
+			checkoutCmd.Dir = c.workDir
+			if err := checkoutCmd.Run(); err != nil {
+				c.logger.Printf("Warning: failed to checkout PR branch %s: %v", pr.HeadRefName, err)
+			}
+		}
+
+		// Fetch reviews requesting changes
+		repoPath := c.config.Repository
+		reviewCmd := exec.CommandContext(ctx, "gh", "api",
+			fmt.Sprintf("repos/%s/pulls/%s/reviews", repoPath, prNumber),
+			"--jq", `[.[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {state: .state, body: .body}]`,
+		)
+		reviewCmd.Env = append(os.Environ(), fmt.Sprintf("GITHUB_TOKEN=%s", c.gitHubToken))
+
+		if reviewOutput, err := reviewCmd.Output(); err == nil {
+			var reviews []prReview
+			if err := json.Unmarshal(reviewOutput, &reviews); err == nil {
+				prWithRev.Reviews = reviews
+			}
+		}
+
+		// Fetch inline review comments
+		commentCmd := exec.CommandContext(ctx, "gh", "api",
+			fmt.Sprintf("repos/%s/pulls/%s/comments", repoPath, prNumber),
+			"--jq", `[.[] | {path: .path, line: .line, body: .body, diffHunk: .diff_hunk}]`,
+		)
+		commentCmd.Env = append(os.Environ(), fmt.Sprintf("GITHUB_TOKEN=%s", c.gitHubToken))
+
+		if commentOutput, err := commentCmd.Output(); err == nil {
+			var comments []prComment
+			if err := json.Unmarshal(commentOutput, &comments); err == nil {
+				prWithRev.Comments = comments
+			}
+		}
+
+		prs = append(prs, prWithRev)
+	}
+
+	return prs, nil
+}
+
+func (c *Controller) buildPromptWithPRs(prs []prWithReviews) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("You are working on repository: %s\n\n", c.config.Repository))
+	sb.WriteString("## PR REVIEW SESSION\n\n")
+	sb.WriteString("You are addressing code review feedback on existing pull request(s).\n\n")
+
+	for _, pr := range prs {
+		sb.WriteString(fmt.Sprintf("### PR #%d: %s\n", pr.Detail.Number, pr.Detail.Title))
+		sb.WriteString(fmt.Sprintf("Branch: %s\n\n", pr.Detail.HeadRefName))
+
+		// Add review comments
+		if len(pr.Reviews) > 0 {
+			sb.WriteString("**Review Feedback:**\n")
+			for _, review := range pr.Reviews {
+				if review.Body != "" {
+					body := review.Body
+					if len(body) > 500 {
+						body = body[:500] + "..."
+					}
+					sb.WriteString(fmt.Sprintf("- [%s] %s\n", review.State, body))
+				}
+			}
+			sb.WriteString("\n")
+		}
+
+		// Add inline comments
+		if len(pr.Comments) > 0 {
+			sb.WriteString("**Inline Comments:**\n")
+			for _, comment := range pr.Comments {
+				body := comment.Body
+				if len(body) > 300 {
+					body = body[:300] + "..."
+				}
+				sb.WriteString(fmt.Sprintf("- File: %s (line %d)\n", comment.Path, comment.Line))
+				sb.WriteString(fmt.Sprintf("  Comment: %s\n", body))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("## Instructions\n\n")
+	sb.WriteString("1. You are ALREADY on the PR branch - do NOT create a new branch\n")
+	sb.WriteString("2. Read and understand the review comments\n")
+	sb.WriteString("3. Make targeted changes to address the feedback\n")
+	sb.WriteString("4. Run tests to verify your changes\n")
+	sb.WriteString("5. Commit with message: \"Address review feedback\"\n")
+	sb.WriteString("6. Push your changes: `git push origin HEAD`\n\n")
+	sb.WriteString("## DO NOT\n\n")
+	sb.WriteString("- Create a new branch (you're already on the PR branch)\n")
+	sb.WriteString("- Close or merge the PR\n")
+	sb.WriteString("- Dismiss reviews\n")
+	sb.WriteString("- Force push (unless absolutely necessary)\n")
+	sb.WriteString("- Make unrelated changes\n")
+
+	return sb.String()
 }
 
 func (c *Controller) buildPromptWithIssues(issues []issueDetail) string {
@@ -383,7 +571,13 @@ func (c *Controller) shouldTerminate() bool {
 		return true
 	}
 
-	// Check if all tasks are complete
+	// For PR review sessions: check if changes were pushed
+	if len(c.config.PRs) > 0 && c.pushedChanges {
+		c.logger.Println("PR review complete: changes pushed")
+		return true
+	}
+
+	// For issue sessions: check if all tasks are complete
 	allComplete := true
 	for _, task := range c.config.Tasks {
 		if !c.completed[task] {

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -39,6 +39,7 @@ type SessionConfig struct {
 	ID            string
 	Repository    string
 	Tasks         []string
+	PRs           []string
 	Agent         string
 	MaxIterations int
 	MaxDuration   string


### PR DESCRIPTION
## Summary

- Adds `--prs` flag to `agentium run` command for PR review sessions
- Agents can now address code review feedback on existing PRs
- Session automatically completes when changes are pushed to PR branch

## Changes

### Go Code
- `internal/cli/run.go`: Add `--prs` flag and validation
- `internal/config/config.go`: Add `PRs []string` to SessionConfig
- `internal/provisioner/provisioner.go`: Add PRs to SessionConfig
- `internal/controller/controller.go`: PR fetching, branch checkout, prompt building, push detection
- `internal/agent/interface.go`: Add PRs to Session, PushedChanges to IterationResult
- `internal/agent/claudecode/adapter.go`: Push detection in ParseOutput

### Bootstrap Files
- `bootstrap/session.sh`: PR mode functions and logic
- `bootstrap/cloud-init.yaml`: PR metadata support
- `bootstrap/variables.tf`: Add `prs` variable
- `bootstrap/main.tf`: Pass PRs metadata to VM
- `bootstrap/SYSTEM.md`: PR review session instructions

## Usage

```bash
# Work on issues (existing)
agentium run --repo org/repo --issues 2,3

# Address PR review feedback (new)
agentium run --repo org/repo --prs 42

# Both together
agentium run --repo org/repo --issues 5 --prs 42,43
```

## Test plan

- [x] All Go tests pass
- [x] Terraform validates successfully
- [x] Shell script syntax check passes
- [ ] Manual test with real PR (optional)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/code)