### PR TITLE
Add .agentium/AGENT.md for Agentium project context

### DIFF
--- a/.agentium/AGENT.md
+++ b/.agentium/AGENT.md
@@ -1,0 +1,73 @@
+# Agentium Project Agent Instructions
+
+This file provides project-specific context for agents working on the Agentium codebase.
+
+## Project Overview
+
+Agentium is an ephemeral cloud execution framework for running AI coding agents safely. Agents run in containerized environments on session-scoped VMs that self-terminate after completing tasks.
+
+## Project Structure
+
+```
+agentium/
+├── cmd/
+│   ├── agentium/       # CLI entry point (main user interface)
+│   └── controller/     # Session controller entry point (runs on VM)
+├── internal/
+│   ├── cli/            # CLI command implementations
+│   ├── config/         # Configuration loading and validation
+│   ├── controller/     # Session lifecycle management
+│   ├── agent/          # Agent adapters (claudecode, aider)
+│   ├── provisioner/    # Cloud VM provisioning
+│   └── cloud/          # Cloud provider clients (aws, gcp, azure)
+├── terraform/modules/  # Terraform modules for VM/IAM/networking
+├── docker/             # Agent runtime container Dockerfiles
+└── bootstrap/          # Phase 0 bootstrap system (GCP-only, script-based)
+```
+
+## Core Concepts
+
+- **Session**: A single VM lifecycle executing one or more tasks
+- **Iteration**: One agent execution cycle within a session
+- **Agent Adapter**: Pluggable interface for different AI agents (Claude Code, Aider)
+- **Provisioner**: Cloud-specific VM lifecycle management
+- **Session Controller**: Runs on the VM, orchestrates agent containers, enforces termination
+
+## Key Design Constraints
+
+1. **Container-first**: Agent logic always runs in containers, never directly on the VM
+2. **Ephemeral VMs**: VMs are session-scoped and self-destruct on completion
+3. **PR-driven changes**: Agents create PRs, never deploy directly
+4. **Least privilege**: Agent VMs have only GitHub read/write access
+5. **Prompt-defined lifecycle**: Iteration limits, time budgets, termination rules come from the prompt
+
+## Build & Test Commands
+
+```bash
+# Build all binaries
+go build ./...
+
+# Run all tests
+go test ./...
+
+# Build specific binaries
+go build -o agentium ./cmd/agentium
+go build -o controller ./cmd/controller
+```
+
+## Current Implementation Status
+
+- **GCP**: Fully functional (provisioner, terraform, bootstrap)
+- **AWS/Azure**: Planned, not yet implemented
+- **GitHub App auth**: Implemented in bootstrap, stubbed in Go controller
+- **Cloud Logging**: Not yet implemented
+
+## Architecture Reference
+
+For detailed requirements, design rationale, and functional specifications, see `agentium_prd.md` in the repository root.
+
+## Off-Limits Areas
+
+- Do not modify GitHub Actions workflows without explicit approval
+- Do not add cloud provider dependencies without considering multi-cloud support
+- Do not store secrets or credentials in code


### PR DESCRIPTION
## Summary

- Adds `.agentium/AGENT.md` with condensed architectural overview for agents working on the Agentium codebase
- Provides project structure, core concepts, design constraints, and build commands
- References `agentium_prd.md` for detailed specifications (avoids passing 500+ lines for every issue)

## Rationale

The full PRD is too much context to require for every issue. This file gives agents enough context to work effectively (~70 lines) while pointing to the PRD for deeper architectural questions.

This also establishes the pattern for other repositories: `.agentium/AGENT.md` is the standard location for per-project agent instructions.

## Related

- Created #47 to track adding an `agentium init` command for setting up other repos

## Test plan

- [x] File follows the template structure from `bootstrap/AGENT.template.md`
- [x] Content accurately reflects current project structure and constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)