### PR TITLE
feat(bootstrap): Add PR support and combined PR+Issue sessions

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -140,6 +140,27 @@ Work on multiple issues in one session:
 ./run.sh --repo andymwolf/agentium --issue 42,43,44
 ```
 
+### PR Review Sessions
+
+Address code review feedback on existing PRs:
+
+```bash
+./run.sh --repo andymwolf/agentium --pr 42
+```
+
+### Combined PR and Issue Sessions
+
+Process both PR reviews and new issues in one session. PRs are processed first:
+
+```bash
+./run.sh --repo andymwolf/agentium --pr 42 --issue 6,47
+```
+
+This creates a work queue that:
+1. Addresses PR #42 review feedback first
+2. Then works on Issue #6
+3. Finally works on Issue #47
+
 ### Destroy Session
 
 Clean up resources:


### PR DESCRIPTION
## Summary

- Add `--pr` flag to `run.sh` for specifying PR numbers
- Allow both `--issue` and `--pr` to be used together in a single session
- Implement queue-based processing in `session.sh` that processes PRs first, then issues
- Update validation to require at least `--issue` or `--pr`
- Update usage documentation and README with new examples

## Test plan

- [ ] Test PR-only mode: `./run.sh --repo owner/repo --pr 42 --dry-run`
- [ ] Test issue-only mode: `./run.sh --repo owner/repo --issue 6,47 --dry-run`
- [ ] Test combined mode: `./run.sh --repo owner/repo --pr 42 --issue 6,47 --dry-run`
- [ ] Verify terraform variables are passed correctly
- [ ] Run actual session and verify PRs are processed before issues in VM logs

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)