### PR TITLE
Fix session.sh system prompt flags to pass file contents

### DIFF
--- a/bootstrap/session.sh
+++ b/bootstrap/session.sh
@@ -327,16 +327,17 @@ run_claude() {
     log_info "Running Claude Code (iteration ${iteration})"
 
     # Build Claude command
+    # Note: --system-prompt expects content, not a file path
     local claude_args=(
         "--print"
         "--dangerously-skip-permissions"
-        "--system-prompt" "${system_md}"
+        "--system-prompt" "$(cat "${system_md}")"
     )
 
     # Check for project-specific instructions
     if [[ -f "${WORKSPACE}/.agentium/AGENT.md" ]]; then
         log_info "Found project-specific instructions: .agentium/AGENT.md"
-        claude_args+=("--append-system-prompt" "${WORKSPACE}/.agentium/AGENT.md")
+        claude_args+=("--append-system-prompt" "$(cat "${WORKSPACE}/.agentium/AGENT.md")")
     fi
 
     # Export session variables for Claude


### PR DESCRIPTION
## Summary

- Fix `--system-prompt` flag to pass actual file contents via `$(cat "${system_md}")` instead of the file path
- Fix `--append-system-prompt` flag similarly for project-specific AGENT.md

Closes #59

## Root Cause

The Claude CLI `--system-prompt` and `--append-system-prompt` flags expect prompt **content** as a string argument, not file paths. The script was passing `/tmp/SYSTEM.md` as the literal system prompt text, causing "No messages returned" errors.

## Test Plan

- [ ] Run `bootstrap/run.sh` to launch an Agentium session
- [ ] Verify the session processes issues without "No messages returned" error
- [ ] Confirm Claude receives the actual SYSTEM.md content as its system prompt

🤖 Generated with [Claude Code](https://claude.ai/code)