### PR TITLE
feat(bootstrap): Add Packer template for pre-baked GCP image

### DIFF
--- a/bootstrap/cloud-init-prebaked.yaml
+++ b/bootstrap/cloud-init-prebaked.yaml
@@ -1,0 +1,96 @@
+#cloud-config
+# Agentium Streamlined Cloud-Init (for pre-baked images)
+#
+# This cloud-init script is used with pre-baked machine images that already
+# have all tools installed (Docker, Node.js, Claude Code, gh, gcloud).
+# It only handles runtime configuration: starting services and launching
+# the session based on instance metadata.
+#
+# For full provisioning (stock Ubuntu), see cloud-init.yaml instead.
+
+runcmd:
+  # Start Docker (already installed in image)
+  - systemctl start docker
+
+  # Ensure workspace directory exists and has correct ownership
+  - mkdir -p /workspace
+  - chown agentium:agentium /workspace
+
+  # Log startup
+  - echo "Agentium pre-baked image startup at $(date)" >> /var/log/agentium-init.log
+
+  # Read session config from instance metadata and start session
+  - |
+    # Helper function to fetch metadata with retry
+    fetch_metadata() {
+      local key="$1"
+      local max_attempts=10
+      local attempt=1
+      while [ $attempt -le $max_attempts ]; do
+        value=$(curl -sf -H "Metadata-Flavor: Google" \
+          "http://metadata.google.internal/computeMetadata/v1/instance/attributes/${key}" 2>/dev/null)
+        if [ -n "$value" ]; then
+          echo "$value"
+          return 0
+        fi
+        sleep 2
+        attempt=$((attempt + 1))
+      done
+      return 1
+    }
+
+    # Check if we should auto-start a session
+    if fetch_metadata "agentium-autostart" > /dev/null 2>&1; then
+      echo "Auto-start enabled, fetching session config..." >> /var/log/agentium-init.log
+
+      # Export session config from metadata
+      export AGENTIUM_SESSION_ID=$(fetch_metadata "agentium-session-id")
+      export AGENTIUM_REPOSITORY=$(fetch_metadata "agentium-repository")
+      export AGENTIUM_ISSUES=$(fetch_metadata "agentium-issues")
+      export GITHUB_APP_ID=$(fetch_metadata "github-app-id")
+      export GITHUB_INSTALLATION_ID=$(fetch_metadata "github-installation-id")
+      export GITHUB_PRIVATE_KEY_SECRET=$(fetch_metadata "github-private-key-secret")
+      export ANTHROPIC_API_KEY_SECRET=$(fetch_metadata "anthropic-api-key-secret")
+
+      # Fetch PR metadata (optional, for PR review sessions)
+      export AGENTIUM_PRS=$(fetch_metadata "agentium-prs" 2>/dev/null || echo "")
+
+      # Validate required metadata - need repository and at least issues or PRs
+      if [ -z "$AGENTIUM_REPOSITORY" ]; then
+        echo "ERROR: Missing required metadata (repository)" >> /var/log/agentium-init.log
+        exit 1
+      fi
+      if [ -z "$AGENTIUM_ISSUES" ] && [ -z "$AGENTIUM_PRS" ]; then
+        echo "ERROR: Missing required metadata (at least issues or prs required)" >> /var/log/agentium-init.log
+        exit 1
+      fi
+
+      # Fetch Anthropic API key from Secret Manager if configured
+      if [ -n "$ANTHROPIC_API_KEY_SECRET" ]; then
+        # Ensure gcloud is in PATH
+        if [ -f /opt/google-cloud-sdk/path.bash.inc ]; then
+          source /opt/google-cloud-sdk/path.bash.inc
+        fi
+        export ANTHROPIC_API_KEY=$(gcloud secrets versions access latest --secret="$ANTHROPIC_API_KEY_SECRET")
+      fi
+
+      # Mark as ready
+      touch /var/run/agentium-ready
+
+      # Run the session as the agentium user (non-root)
+      sudo -u agentium \
+        HOME="/home/agentium" \
+        AGENTIUM_SESSION_ID="$AGENTIUM_SESSION_ID" \
+        AGENTIUM_REPOSITORY="$AGENTIUM_REPOSITORY" \
+        AGENTIUM_ISSUES="${AGENTIUM_ISSUES:-}" \
+        AGENTIUM_PRS="${AGENTIUM_PRS:-}" \
+        GITHUB_APP_ID="$GITHUB_APP_ID" \
+        GITHUB_INSTALLATION_ID="$GITHUB_INSTALLATION_ID" \
+        GITHUB_PRIVATE_KEY_SECRET="$GITHUB_PRIVATE_KEY_SECRET" \
+        ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+        /usr/local/bin/agentium-session 2>&1 | tee /var/log/agentium-session.log
+    fi
+
+final_message: |
+  Agentium pre-baked image ready!
+  Image info: $(cat /etc/agentium-image 2>/dev/null || echo "unknown")

--- a/bootstrap/packer/README.md
+++ b/bootstrap/packer/README.md
@@ -1,0 +1,84 @@
+# Agentium Pre-Baked GCP Image
+
+This directory contains a [Packer](https://www.packer.io/) template for building a pre-baked GCP machine image with all Agentium dependencies pre-installed.
+
+## Why?
+
+The default bootstrap process installs all tools via cloud-init on every VM startup, which takes 3-8 minutes. By pre-baking these tools into a machine image, cold start time is reduced to under 1 minute.
+
+## Pre-installed Tools
+
+The image includes:
+- **Docker** - Container runtime
+- **Node.js v20** - JavaScript runtime (via NodeSource)
+- **Claude Code CLI** - `@anthropic-ai/claude-code`
+- **GitHub CLI** - `gh`
+- **gcloud CLI** - Google Cloud SDK
+- **Utilities** - git, curl, jq, unzip, openssl
+
+## Prerequisites
+
+1. [Packer](https://www.packer.io/downloads) >= 1.9.0
+2. GCP credentials configured (`gcloud auth application-default login`)
+3. A GCP project with Compute Engine API enabled
+
+## Building the Image
+
+```bash
+cd bootstrap/packer
+
+# Initialize Packer plugins
+packer init .
+
+# Validate the template
+packer validate -var "project_id=YOUR_PROJECT_ID" .
+
+# Build the image
+packer build -var "project_id=YOUR_PROJECT_ID" .
+```
+
+Or using a variables file:
+
+```bash
+cp agentium.pkrvars.hcl.example agentium.pkrvars.hcl
+# Edit agentium.pkrvars.hcl with your values
+packer build -var-file="agentium.pkrvars.hcl" .
+```
+
+## Using the Image
+
+Once built, the image will be available in your GCP project under the `agentium` image family. To use it with the bootstrap Terraform:
+
+```bash
+cd bootstrap
+
+# Use the image family (latest image)
+terraform apply -var "vm_image=projects/YOUR_PROJECT_ID/global/images/family/agentium"
+
+# Or use a specific image
+terraform apply -var "vm_image=projects/YOUR_PROJECT_ID/global/images/agentium-v1-1234567890"
+```
+
+When `vm_image` is set, the bootstrap uses a streamlined cloud-init (`cloud-init-prebaked.yaml`) that skips tool installation and only handles runtime configuration (metadata fetching and session startup).
+
+## Versioning
+
+Images are named with the pattern: `agentium-{version}-{timestamp}`
+
+Use the `image_version` variable to tag builds:
+
+```bash
+packer build -var "project_id=YOUR_PROJECT_ID" -var "image_version=v2" .
+```
+
+## Rebuilding
+
+The image should be rebuilt periodically to pick up:
+- Claude Code CLI updates
+- Node.js security patches
+- Docker updates
+- OS security updates
+
+## Fallback
+
+If the pre-baked image is unavailable or broken, simply omit the `vm_image` variable. The bootstrap will fall back to stock Ubuntu 22.04 with full cloud-init provisioning (the original 3-8 minute startup).

--- a/bootstrap/packer/agentium.pkr.hcl
+++ b/bootstrap/packer/agentium.pkr.hcl
@@ -1,0 +1,57 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = ">= 1.1.0"
+    }
+  }
+}
+
+source "googlecompute" "agentium" {
+  project_id          = var.project_id
+  zone                = var.zone
+  machine_type        = var.machine_type
+  source_image_family = "ubuntu-2204-lts"
+  source_image_project_id = ["ubuntu-os-cloud"]
+  ssh_username        = "packer"
+  disk_size           = var.disk_size_gb
+  disk_type           = "pd-ssd"
+  image_name          = "agentium-${var.image_version}-{{timestamp}}"
+  image_family        = "agentium"
+  image_description   = "Agentium pre-baked image with Docker, Node.js, Claude Code, and other tools"
+  image_labels = {
+    agentium = "true"
+    version  = var.image_version
+  }
+}
+
+build {
+  sources = ["source.googlecompute.agentium"]
+
+  # Upload provisioning script
+  provisioner "file" {
+    source      = "${path.root}/scripts/provision.sh"
+    destination = "/tmp/provision.sh"
+  }
+
+  # Run provisioning script
+  provisioner "shell" {
+    inline = [
+      "chmod +x /tmp/provision.sh",
+      "sudo /tmp/provision.sh",
+    ]
+  }
+
+  # Clean up for image creation
+  provisioner "shell" {
+    inline = [
+      "sudo apt-get clean",
+      "sudo rm -rf /var/lib/apt/lists/*",
+      "sudo rm -rf /tmp/*",
+      "sudo rm -rf /var/tmp/*",
+      "sudo truncate -s 0 /var/log/*.log",
+      "sudo truncate -s 0 /var/log/**/*.log 2>/dev/null || true",
+      "sudo sync",
+    ]
+  }
+}

--- a/bootstrap/packer/agentium.pkrvars.hcl.example
+++ b/bootstrap/packer/agentium.pkrvars.hcl.example
@@ -1,0 +1,8 @@
+# Agentium Packer Variables
+# Copy this file to agentium.pkrvars.hcl and fill in your values.
+
+project_id    = "your-gcp-project-id"
+zone          = "us-central1-a"
+machine_type  = "e2-medium"
+disk_size_gb  = 50
+image_version = "v1"

--- a/bootstrap/packer/scripts/provision.sh
+++ b/bootstrap/packer/scripts/provision.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Agentium Image Provisioning Script
+#
+# This script installs all required tools into the base Ubuntu 22.04 image
+# so that VMs can start sessions without lengthy cloud-init installations.
+#
+# Tools installed:
+#   - Docker
+#   - Node.js v20
+#   - Claude Code CLI (@anthropic-ai/claude-code)
+#   - GitHub CLI (gh)
+#   - gcloud CLI (if not already present on GCP)
+#   - Standard utilities (jq, curl, git, unzip, openssl)
+
+set -euo pipefail
+
+echo "=== Agentium Image Provisioning ==="
+echo "Started at: $(date)"
+
+# -----------------------------------------------
+# System packages
+# -----------------------------------------------
+echo ">>> Updating system packages..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get upgrade -y
+apt-get install -y \
+  git \
+  curl \
+  jq \
+  unzip \
+  apt-transport-https \
+  ca-certificates \
+  gnupg \
+  lsb-release \
+  openssl \
+  software-properties-common
+
+# -----------------------------------------------
+# Docker
+# -----------------------------------------------
+echo ">>> Installing Docker..."
+curl -fsSL https://get.docker.com | sh
+systemctl enable docker
+
+# -----------------------------------------------
+# Node.js v20 (via NodeSource)
+# -----------------------------------------------
+echo ">>> Installing Node.js v20..."
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y nodejs
+
+echo "Node.js version: $(node --version)"
+echo "npm version: $(npm --version)"
+
+# -----------------------------------------------
+# Claude Code CLI
+# -----------------------------------------------
+echo ">>> Installing Claude Code CLI..."
+npm install -g @anthropic-ai/claude-code
+
+# -----------------------------------------------
+# GitHub CLI
+# -----------------------------------------------
+echo ">>> Installing GitHub CLI..."
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+apt-get update
+apt-get install -y gh
+
+# -----------------------------------------------
+# gcloud CLI
+# -----------------------------------------------
+echo ">>> Installing gcloud CLI..."
+if ! command -v gcloud &> /dev/null; then
+  export CLOUDSDK_INSTALL_DIR=/opt
+  curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/opt
+  cat > /etc/profile.d/gcloud.sh << 'GCLOUD_PROFILE'
+if [ -f /opt/google-cloud-sdk/path.bash.inc ]; then
+  source /opt/google-cloud-sdk/path.bash.inc
+fi
+GCLOUD_PROFILE
+else
+  echo "gcloud already installed: $(gcloud --version | head -1)"
+fi
+
+# -----------------------------------------------
+# Create agentium user
+# -----------------------------------------------
+echo ">>> Creating agentium user..."
+if ! id agentium &>/dev/null; then
+  useradd -m -s /bin/bash agentium
+  echo "agentium ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agentium
+  chmod 0440 /etc/sudoers.d/agentium
+fi
+usermod -aG docker agentium
+
+# -----------------------------------------------
+# Create workspace directory
+# -----------------------------------------------
+echo ">>> Creating workspace directory..."
+mkdir -p /workspace
+chown agentium:agentium /workspace
+chmod 755 /workspace
+
+# -----------------------------------------------
+# Set up agentium user home directory
+# -----------------------------------------------
+mkdir -p /home/agentium/.config
+chown -R agentium:agentium /home/agentium
+
+# -----------------------------------------------
+# Git configuration
+# -----------------------------------------------
+echo ">>> Configuring git..."
+cat > /etc/gitconfig << 'GITCONFIG'
+[user]
+    name = Agentium Bot
+    email = bot@agentium.dev
+[init]
+    defaultBranch = main
+[safe]
+    directory = /workspace
+GITCONFIG
+
+# -----------------------------------------------
+# Session script placeholder
+# -----------------------------------------------
+echo ">>> Installing session launcher..."
+cat > /usr/local/bin/agentium-session << 'SESSION'
+#!/bin/bash
+# Fetch and run the latest session script from agentium repo
+curl -sL https://raw.githubusercontent.com/andymwolf/agentium/main/bootstrap/session.sh \
+  -o /tmp/session.sh
+chmod +x /tmp/session.sh
+exec /tmp/session.sh "$@"
+SESSION
+chmod 755 /usr/local/bin/agentium-session
+
+# -----------------------------------------------
+# Version marker
+# -----------------------------------------------
+echo ">>> Writing version marker..."
+cat > /etc/agentium-image << EOF
+image_build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+node_version=$(node --version)
+npm_version=$(npm --version)
+docker_version=$(docker --version)
+gh_version=$(gh --version | head -1)
+EOF
+
+echo "=== Agentium Image Provisioning Complete ==="
+echo "Completed at: $(date)"

--- a/bootstrap/packer/variables.pkr.hcl
+++ b/bootstrap/packer/variables.pkr.hcl
@@ -1,0 +1,28 @@
+variable "project_id" {
+  description = "GCP project ID where the image will be created"
+  type        = string
+}
+
+variable "zone" {
+  description = "GCP zone for the build VM"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "machine_type" {
+  description = "Machine type for the build VM"
+  type        = string
+  default     = "e2-medium"
+}
+
+variable "disk_size_gb" {
+  description = "Disk size for the build VM in GB"
+  type        = number
+  default     = 50
+}
+
+variable "image_version" {
+  description = "Version tag for the image (used in naming and labels)"
+  type        = string
+  default     = "v1"
+}

--- a/bootstrap/terraform.tfvars.example
+++ b/bootstrap/terraform.tfvars.example
@@ -46,3 +46,9 @@ github_private_key_secret = "github-app-key"
 
 # Custom session ID (auto-generated if not provided)
 # session_id = "my-custom-session"
+
+# Pre-baked VM image (reduces cold start from ~5min to <1min)
+# Build with: cd bootstrap/packer && packer build -var "project_id=..." .
+# Use image family for latest: "projects/YOUR_PROJECT/global/images/family/agentium"
+# Use specific image: "projects/YOUR_PROJECT/global/images/agentium-v1-1234567890"
+# vm_image = ""

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -117,3 +117,9 @@ variable "max_session_hours" {
     error_message = "Max session hours must be between 1 and 24."
   }
 }
+
+variable "vm_image" {
+  description = "Custom VM image to use (e.g., 'projects/my-project/global/images/agentium-v1-...'). If empty, uses stock Ubuntu 22.04 LTS with full cloud-init provisioning."
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -67,6 +67,12 @@ variable "max_run_duration" {
   default     = "7200s"
 }
 
+variable "vm_image" {
+  description = "Custom VM image to use (e.g., 'projects/my-project/global/images/agentium-v1-...'). If empty, uses stock Ubuntu 22.04 LTS."
+  type        = string
+  default     = ""
+}
+
 variable "network" {
   description = "VPC network name"
   type        = string
@@ -156,7 +162,7 @@ resource "google_compute_instance" "agentium" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      image = var.vm_image != "" ? var.vm_image : "ubuntu-os-cloud/ubuntu-2204-lts"
       size  = var.disk_size_gb
       type  = "pd-ssd"
     }


### PR DESCRIPTION
Add a Packer template and provisioning scripts to create a pre-baked
GCP machine image with all Agentium dependencies pre-installed (Docker,
Node.js v20, Claude Code CLI, GitHub CLI, gcloud CLI). This reduces
cold start time from 3-8 minutes to under 1 minute.

Changes:
- Add bootstrap/packer/ with HCL template, variables, and provision script
- Add bootstrap/cloud-init-prebaked.yaml for runtime-only configuration
- Add vm_image variable to both Terraform configs (bootstrap and module)
- Terraform conditionally uses streamlined cloud-init with pre-baked images
- Fallback to stock Ubuntu 22.04 + full cloud-init when vm_image is unset

Closes #52
Co-Authored-By: Claude <noreply@anthropic.com>