### PR TITLE
feat(auth): Add Claude Max OAuth support via auth.json

### DIFF
--- a/configs/example.agentium.yaml
+++ b/configs/example.agentium.yaml
@@ -29,6 +29,12 @@ defaults:
   max_iterations: 30                # Maximum iterations before termination
   max_duration: "2h"                # Maximum session duration
 
+# Claude AI authentication settings
+# Options: "api" (default, uses ANTHROPIC_API_KEY) or "oauth" (uses auth.json from `claude login`)
+claude:
+  auth_mode: "api"                            # "api" or "oauth"
+  auth_json_path: "~/.config/claude-code/auth.json"  # Path to auth.json (for oauth mode)
+
 # Controller settings (optional)
 controller:
   image: "ghcr.io/andywolf/agentium-controller:latest"

--- a/internal/agent/claudecode/adapter.go
+++ b/internal/agent/claudecode/adapter.go
@@ -37,12 +37,18 @@ func (a *Adapter) ContainerImage() string {
 
 // BuildEnv constructs environment variables for the Claude Code container
 func (a *Adapter) BuildEnv(session *agent.Session, iteration int) map[string]string {
+	authMode := session.ClaudeAuthMode
+	if authMode == "" {
+		authMode = "api"
+	}
+
 	env := map[string]string{
-		"GITHUB_TOKEN":          session.GitHubToken,
-		"AGENTIUM_SESSION_ID":   session.ID,
-		"AGENTIUM_ITERATION":    fmt.Sprintf("%d", iteration),
-		"AGENTIUM_REPOSITORY":   session.Repository,
-		"AGENTIUM_WORKDIR":      "/workspace",
+		"GITHUB_TOKEN":            session.GitHubToken,
+		"AGENTIUM_SESSION_ID":     session.ID,
+		"AGENTIUM_ITERATION":      fmt.Sprintf("%d", iteration),
+		"AGENTIUM_REPOSITORY":     session.Repository,
+		"AGENTIUM_WORKDIR":        "/workspace",
+		"AGENTIUM_AUTH_MODE":      authMode,
 		"CLAUDE_CODE_USE_BEDROCK": "0",
 	}
 

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -2,16 +2,17 @@ package agent
 
 // Session represents an agent session with all necessary context
 type Session struct {
-	ID            string
-	Repository    string
-	Tasks         []string
-	PRs           []string // PR numbers for review sessions
-	WorkDir       string
-	GitHubToken   string
-	MaxIterations int
-	MaxDuration   string
-	Prompt        string
-	Metadata      map[string]string
+	ID             string
+	Repository     string
+	Tasks          []string
+	PRs            []string // PR numbers for review sessions
+	WorkDir        string
+	GitHubToken    string
+	MaxIterations  int
+	MaxDuration    string
+	Prompt         string
+	Metadata       map[string]string
+	ClaudeAuthMode string // "api" or "oauth"
 }
 
 // IterationResult represents the outcome of a single agent iteration

--- a/internal/provisioner/gcp.go
+++ b/internal/provisioner/gcp.go
@@ -74,6 +74,7 @@ use_spot           = %t
 disk_size_gb       = %d
 controller_image   = "%s"
 session_config     = %s
+claude_auth_mode   = "%s"
 `,
 		config.Session.ID,
 		config.Region,
@@ -82,7 +83,13 @@ session_config     = %s
 		config.DiskSizeGB,
 		config.ControllerImage,
 		string(sessionJSON),
+		config.Session.ClaudeAuth.AuthMode,
 	)
+
+	// Add auth JSON only when oauth mode with auth data present
+	if config.Session.ClaudeAuth.AuthMode == "oauth" && config.Session.ClaudeAuth.AuthJSONBase64 != "" {
+		tfvars += fmt.Sprintf("claude_auth_json   = \"%s\"\n", config.Session.ClaudeAuth.AuthJSONBase64)
+	}
 
 	tfvarsPath := filepath.Join(workDir, "terraform.tfvars")
 	if err := os.WriteFile(tfvarsPath, []byte(tfvars), 0644); err != nil {

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -34,6 +34,12 @@ type VMConfig struct {
 	ControllerImage string
 }
 
+// ClaudeAuthConfig contains Claude authentication configuration for the VM
+type ClaudeAuthConfig struct {
+	AuthMode       string `json:"auth_mode"`
+	AuthJSONBase64 string `json:"auth_json_base64,omitempty"`
+}
+
 // SessionConfig contains the session configuration to pass to the VM
 type SessionConfig struct {
 	ID            string
@@ -45,6 +51,7 @@ type SessionConfig struct {
 	MaxDuration   string
 	Prompt        string
 	GitHub        GitHubConfig
+	ClaudeAuth    ClaudeAuthConfig
 }
 
 // GitHubConfig contains GitHub authentication configuration


### PR DESCRIPTION
## Summary

- Adds support for Claude Max subscription authentication (OAuth tokens in `auth.json`) as an alternative to API keys
- Users who have run `claude login` can configure `auth_mode: oauth` to use their existing credentials
- Auth.json flows securely: local file → base64 encode → Terraform variable (sensitive) → cloud-init → read-only container mount

## Changes

- **config.go**: Add `ClaudeConfig` struct with `auth_mode` and `auth_json_path` fields, defaults, and validation
- **provisioner.go**: Add `ClaudeAuthConfig` struct to `SessionConfig`
- **interface.go**: Add `ClaudeAuthMode` field to agent `Session`
- **run.go**: Add `--claude-auth-mode` CLI flag, auth.json reading/validation, and base64 encoding
- **gcp.go**: Pass `claude_auth_mode` and `claude_auth_json` to Terraform
- **main.tf**: Add Terraform variables, conditional cloud-init write_file, and container volume mount
- **controller.go**: Set `ClaudeAuthMode` on session and mount auth.json into agent container
- **adapter.go**: Set `AGENTIUM_AUTH_MODE` environment variable in agent container
- **example.agentium.yaml**: Document the new `claude` config section

## Security

- `claude_auth_json` Terraform variable marked `sensitive = true`
- auth.json written with `0600` permissions on VM
- Mounted read-only (`:ro`) into agent container
- VM is ephemeral — destroyed after session

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Configure `auth_mode: oauth` in .agentium.yaml and verify auth.json is read
- [ ] Run with `--claude-auth-mode oauth` and verify it overrides config
- [ ] Verify error when auth.json is missing with helpful instructions
- [ ] Verify default behavior (api mode) remains unchanged

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)