### PR TITLE
ci: Add GitHub Actions workflow for Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-agents:
     name: Build ${{ matrix.agent }} Agent
@@ -84,8 +86,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: docker/${{ matrix.agent }}
           file: docker/${{ matrix.agent }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker.yml` to automatically build and push Docker images to GHCR
- Builds three images in parallel: `agentium-controller`, `agentium-claudecode`, `agentium-aider`
- Triggers on push to `main` (when docker/, cmd/, internal/, go.mod, or go.sum change) and on manual dispatch
- Tags images with `latest` and the commit SHA for versioning

## Test plan

- [ ] Merge to main and verify the workflow runs successfully
- [ ] Confirm images appear at `ghcr.io/andymwolf/agentium-controller`, `agentium-claudecode`, `agentium-aider`
- [ ] Verify manual dispatch trigger works from the Actions tab
- [ ] Ensure GHCR packages are accessible (may need to set visibility to public or grant access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)