### PR TITLE
fix(ci): Add setup-buildx-action for GHA cache support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -66,6 +69,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- Fixes the Docker workflow failure: "Cache export is not supported for the docker driver"
- Adds `docker/setup-buildx-action@v3` to both controller and agent build jobs
- This creates a buildx builder with the `docker-container` driver, which supports the GHA cache backend

## Test plan

- [ ] Merge and verify workflow passes
- [ ] Confirm images are pushed to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)