### PR TITLE
fix(docker): Fix build failures across all images

### DIFF
--- a/docker/aider/Dockerfile
+++ b/docker/aider/Dockerfile
@@ -24,8 +24,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
 # Install Aider
 RUN pip install --no-cache-dir aider-chat
 
-# Create non-root user
-RUN useradd -m -u 1000 agentium
+# Create non-root user (remove any existing UID 1000 user from base image)
+RUN getent passwd 1000 > /dev/null 2>&1 && userdel -r $(getent passwd 1000 | cut -d: -f1) || true && \
+    useradd -m -u 1000 agentium
 
 # Create workspace
 RUN mkdir -p /workspace && chown agentium:agentium /workspace

--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -26,8 +26,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
 # Install Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
 
-# Create non-root user
-RUN useradd -m -u 1000 agentium
+# Create non-root user (remove node user which owns UID 1000 in base image)
+RUN userdel -r node && useradd -m -u 1000 agentium
 
 # Create workspace
 RUN mkdir -p /workspace && chown agentium:agentium /workspace

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -29,10 +29,13 @@ RUN apk add --no-cache \
     git \
     curl \
     jq \
-    bash
+    bash \
+    python3
 
-# Install gcloud CLI
-RUN curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/opt
+# Install gcloud CLI (static tarball for Alpine compatibility)
+RUN curl -sSL https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz | \
+    tar xz -C /opt && \
+    /opt/google-cloud-sdk/install.sh --quiet --path-update=false
 ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 
 # Install GitHub CLI


### PR DESCRIPTION
## Summary

- **Controller**: The gcloud SDK interactive installer (`curl | bash`) doesn't work on Alpine — it requires Python which wasn't installed. Fixed by adding `python3` to apk packages and using the static tarball with `install.sh --quiet`.
- **claudecode**: `node:20-slim` base image has a `node` user at UID 1000. `useradd -u 1000 agentium` fails with exit code 4 (UID in use). Fixed by removing the existing user first.
- **aider**: Added defensive UID 1000 conflict handling for safety.

## Test plan

- [ ] Merge and trigger workflow manually
- [ ] All three images build and push successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)