### PR TITLE
fix(terraform): Fix all Terraform module errors preventing provisioning

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -188,11 +188,12 @@ func runSession(cmd *cobra.Command, args []string) error {
 
 	// Build VM config
 	vmConfig := provisioner.VMConfig{
-		Region:       cfg.Cloud.Region,
-		MachineType:  cfg.Cloud.MachineType,
-		UseSpot:      cfg.Cloud.UseSpot,
-		DiskSizeGB:   cfg.Cloud.DiskSizeGB,
-		Session:      sessionConfig,
+		Project:         cfg.Cloud.Project,
+		Region:          cfg.Cloud.Region,
+		MachineType:     cfg.Cloud.MachineType,
+		UseSpot:         cfg.Cloud.UseSpot,
+		DiskSizeGB:      cfg.Cloud.DiskSizeGB,
+		Session:         sessionConfig,
 		ControllerImage: cfg.Controller.Image,
 	}
 

--- a/internal/provisioner/gcp.go
+++ b/internal/provisioner/gcp.go
@@ -68,6 +68,7 @@ func (p *GCPProvisioner) Provision(ctx context.Context, config VMConfig) (*Provi
 	// Create terraform.tfvars
 	tfvars := fmt.Sprintf(`
 session_id         = "%s"
+project_id         = "%s"
 region             = "%s"
 machine_type       = "%s"
 use_spot           = %t
@@ -77,12 +78,13 @@ session_config     = %s
 claude_auth_mode   = "%s"
 `,
 		config.Session.ID,
+		config.Project,
 		config.Region,
 		config.MachineType,
 		config.UseSpot,
 		config.DiskSizeGB,
 		config.ControllerImage,
-		string(sessionJSON),
+		fmt.Sprintf("%q", string(sessionJSON)),
 		config.Session.ClaudeAuth.AuthMode,
 	)
 

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -26,6 +26,7 @@ type Provisioner interface {
 
 // VMConfig contains configuration for provisioning a VM
 type VMConfig struct {
+	Project         string
 	Region          string
 	MachineType     string
 	UseSpot         bool


### PR DESCRIPTION
## Summary

- Removes duplicate `terraform`/`required_providers` block from `main.tf` (already in `versions.tf`)
- Rewrites heredoc-in-conditional for `claude_auth_write_file` as an inline string (Terraform can't parse heredocs inside ternary expressions)
- Merges duplicate `scheduling` blocks — `max_run_duration` is now a dynamic nested block inside the single scheduling block
- Adds `project_id` to `VMConfig` struct and passes it through to Terraform via tfvars
- Removes `data.google_project.current` (unreliable without provider-level project), requires `project_id` directly
- Properly quotes `session_config` JSON string in tfvars using `%q`

Closes #66

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `agentium run --issues 66` successfully provisions a GCP VM (session `agentium-6a0f7e6c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)