### PR TITLE
fix: Correct OAuth credential mount path for Claude Code container

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -29,19 +29,20 @@ RUN npm install -g @anthropic-ai/claude-code
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium
 
-# Create workspace
-RUN mkdir -p /workspace && chown agentium:agentium /workspace
-
-# Configure git for the user
-RUN git config --global user.email "agentium@example.com" && \
-    git config --global user.name "Agentium Bot" && \
-    git config --global init.defaultBranch main
+# Create workspace and Claude config directory
+RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
+    mkdir -p /home/agentium/.claude && chown agentium:agentium /home/agentium/.claude
 
 # Set working directory
 WORKDIR /workspace
 
 # Switch to non-root user
 USER agentium
+
+# Configure git for the agentium user
+RUN git config --global user.email "agentium@example.com" && \
+    git config --global user.name "Agentium Bot" && \
+    git config --global init.defaultBranch main
 
 # Default entrypoint
 ENTRYPOINT ["claude"]

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -785,9 +785,9 @@ func (c *Controller) runIteration(ctx context.Context) (*agent.IterationResult, 
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Mount Claude auth.json for OAuth mode
+	// Mount Claude credentials for OAuth mode
 	if c.config.ClaudeAuth.AuthMode == "oauth" {
-		args = append(args, "-v", "/etc/agentium/claude-auth.json:/home/agentium/.config/claude-code/auth.json:ro")
+		args = append(args, "-v", "/etc/agentium/claude-auth.json:/home/agentium/.claude/.credentials.json:ro")
 	}
 
 	// Add image and command

--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -120,7 +120,7 @@ resource "google_project_iam_member" "compute_admin" {
 
 # Cloud-init script
 locals {
-  claude_auth_volume = var.claude_auth_mode == "oauth" ? "-v /etc/agentium/claude-auth.json:/home/agentium/.config/claude-code/auth.json:ro" : ""
+  claude_auth_volume = var.claude_auth_mode == "oauth" ? "-v /etc/agentium/claude-auth.json:/home/agentium/.claude/.credentials.json:ro" : ""
 
   cloud_init = <<-EOF
 #cloud-config


### PR DESCRIPTION
## Summary
- Fixed the credential file mount path from `~/.config/claude-code/auth.json` to `~/.claude/.credentials.json` (the actual path Claude CLI v2.1.17+ uses on Linux)
- Created `~/.claude/` directory in Dockerfile owned by agentium user so the CLI can write runtime state files (`todos/`, `debug/`)
- Moved `git config --global` commands to run after `USER agentium` so the agentium user has proper git configuration

## Test plan
- [x] Verified Claude CLI reads from `~/.claude/.credentials.json` by examining the bundled source
- [x] Tested with wrong path → `Invalid API key · Please run /login` (exit code 1)
- [x] Tested with correct path but root-owned dir → `EACCES: permission denied, mkdir '/home/agentium/.claude/todos'`
- [x] Tested with correct path and writable dir → Claude responds successfully (exit code 0)
- [x] Built Docker image locally and confirmed git config is set for agentium user
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)