### PR TITLE
fix: Use writable path for workspace on COS

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -147,10 +147,15 @@ func New(config SessionConfig) (*Controller, error) {
 		log.Printf("[controller] Warning: failed to initialize Secret Manager client: %v", err)
 	}
 
+	workDir := os.Getenv("AGENTIUM_WORKDIR")
+	if workDir == "" {
+		workDir = "/workspace"
+	}
+
 	c := &Controller{
 		config:        config,
 		agent:         agentAdapter,
-		workDir:       "/workspace",
+		workDir:       workDir,
 		iteration:     0,
 		maxDuration:   maxDuration,
 		completed:     make(map[string]bool),

--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -139,14 +139,16 @@ write_files:
 runcmd:
   - |
     # Pull and run controller
+    mkdir -p /home/workspace
     docker pull ${var.controller_image}
     docker run --rm \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v /etc/agentium:/etc/agentium:ro \
-      -v /workspace:/workspace \
+      -v /home/workspace:/home/workspace \
       ${local.claude_auth_volume} \
       -e AGENTIUM_CONFIG_PATH=/etc/agentium/session.json \
       -e AGENTIUM_AUTH_MODE=${var.claude_auth_mode} \
+      -e AGENTIUM_WORKDIR=/home/workspace \
       --name agentium-controller \
       ${var.controller_image}
 EOF


### PR DESCRIPTION
## Summary
- COS has a read-only root filesystem; Docker cannot `mkdir /workspace` at `/`
- Changed host workspace volume to `/home/workspace` (writable on COS)
- Controller now reads `AGENTIUM_WORKDIR` env var, defaulting to `/workspace`

Follows up on PR #74 (COS migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)