### PR TITLE
fix: Change OAuth credential file permissions to 0644

### DIFF
--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -131,7 +131,7 @@ write_files:
       ${var.session_config}
 %{ if var.claude_auth_mode == "oauth" && var.claude_auth_json != "" ~}
   - path: /etc/agentium/claude-auth.json
-    permissions: '0600'
+    permissions: '0644'
     encoding: b64
     content: ${var.claude_auth_json}
 %{ endif ~}


### PR DESCRIPTION
## Summary
- Cloud-init writes the OAuth credential file as `root:root 0600`
- When bind-mounted into the agent container, the `agentium` user (UID 1000) cannot read it on Linux
- Claude CLI falls back to API key mode → "Invalid API key · Please run /login"
- Docker Desktop on macOS doesn't enforce these permissions (virtiofs), which is why local testing passed
- Fix: change to `0644` so the non-root container user can read the file

## Test plan
- [ ] Merge and rebuild (Terraform module only, no Docker rebuild needed)
- [ ] Run `agentium run` for a test issue
- [ ] Verify agent authenticates with OAuth successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)