### PR TITLE
Add real-time session status from GCP metadata

### DIFF
--- a/internal/cloud/gcp/metadata_test.go
+++ b/internal/cloud/gcp/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
@@ -171,7 +172,7 @@ func TestComputeMetadataUpdater_UpdateStatus_GetInstanceError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !errors.Is(err, err) || !contains(err.Error(), "failed to get instance metadata") {
+	if !strings.Contains(err.Error(), "failed to get instance metadata") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 
@@ -201,7 +202,7 @@ func TestComputeMetadataUpdater_UpdateStatus_SetMetadataError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !contains(err.Error(), "failed to set instance metadata") {
+	if !strings.Contains(err.Error(), "failed to set instance metadata") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }
@@ -261,15 +262,3 @@ func TestComputeMetadataUpdater_Close(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -222,13 +222,15 @@ func New(config SessionConfig) (*Controller, error) {
 		cloudLogger = cloudLoggerInstance
 	}
 
-	// Initialize metadata updater (non-fatal if unavailable)
+	// Initialize metadata updater (only on GCP instances)
 	var metadataUpdater gcp.MetadataUpdater
-	metadataUpdaterInstance, err := gcp.NewComputeMetadataUpdater(context.Background())
-	if err != nil {
-		log.Printf("[controller] Warning: metadata updater unavailable, session status will not be reported: %v", err)
-	} else {
-		metadataUpdater = metadataUpdaterInstance
+	if gcp.IsRunningOnGCP() {
+		metadataUpdaterInstance, err := gcp.NewComputeMetadataUpdater(context.Background())
+		if err != nil {
+			log.Printf("[controller] Warning: metadata updater unavailable, session status will not be reported: %v", err)
+		} else {
+			metadataUpdater = metadataUpdaterInstance
+		}
 	}
 
 	c := &Controller{


### PR DESCRIPTION
## Summary

- Adds `MetadataUpdater` interface and `ComputeMetadataUpdater` implementation in `internal/cloud/gcp/metadata.go` that writes `agentium-status` JSON to GCP instance metadata via the Compute API
- Controller calls `updateInstanceMetadata()` after each iteration and before shutdown, reporting iteration count, max iterations, completed tasks, and pending tasks
- Metadata updates are best-effort (non-fatal failures logged as warnings)
- Uses fingerprint-based atomic updates to avoid race conditions
- JSON output matches the format already parsed by the provisioner (`internal/provisioner/gcp.go:196-210`)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (7 new tests in `metadata_test.go`)
- [x] Tests cover: adding new key, updating existing key, GetInstance errors, SetMetadata errors, JSON field correctness, interface compliance
- [ ] Deploy to GCP and verify `agentium status <session-id>` shows iteration/task data

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)