### PR TITLE
Fix task completion detection when agent omits status signal

### DIFF
--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"testing"
 
 	"github.com/andywolf/agentium/internal/agent"
@@ -769,4 +771,98 @@ func containsString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestUpdateTaskPhase_PRDetectionFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		taskType    string
+		agentStatus string
+		prsCreated  []string
+		initialPhase TaskPhase
+		wantPhase   TaskPhase
+		wantPR      string
+	}{
+		{
+			name:         "no status signal but PR detected for issue - transitions to complete",
+			taskType:     "issue",
+			agentStatus:  "",
+			prsCreated:   []string{"110"},
+			initialPhase: PhaseImplement,
+			wantPhase:    PhaseComplete,
+			wantPR:       "110",
+		},
+		{
+			name:         "no status signal and no PRs - stays in current phase",
+			taskType:     "issue",
+			agentStatus:  "",
+			prsCreated:   nil,
+			initialPhase: PhaseImplement,
+			wantPhase:    PhaseImplement,
+			wantPR:       "",
+		},
+		{
+			name:         "no status signal but PR detected for PR task - no fallback",
+			taskType:     "pr",
+			agentStatus:  "",
+			prsCreated:   []string{"110"},
+			initialPhase: PhaseAnalyze,
+			wantPhase:    PhaseAnalyze,
+			wantPR:       "",
+		},
+		{
+			name:         "explicit PR_CREATED status takes precedence",
+			taskType:     "issue",
+			agentStatus:  "PR_CREATED",
+			prsCreated:   []string{"110"},
+			initialPhase: PhasePRCreation,
+			wantPhase:    PhaseComplete,
+			wantPR:       "",  // StatusMessage is used, not PRsCreated
+		},
+		{
+			name:         "explicit COMPLETE status - no fallback needed",
+			taskType:     "issue",
+			agentStatus:  "COMPLETE",
+			prsCreated:   nil,
+			initialPhase: PhasePRCreation,
+			wantPhase:    PhaseComplete,
+			wantPR:       "",
+		},
+		{
+			name:         "fallback uses first PR number",
+			taskType:     "issue",
+			agentStatus:  "",
+			prsCreated:   []string{"110", "111"},
+			initialPhase: PhaseImplement,
+			wantPhase:    PhaseComplete,
+			wantPR:       "110",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			taskID := fmt.Sprintf("%s:24", tt.taskType)
+			c := &Controller{
+				taskStates: map[string]*TaskState{
+					taskID: {ID: "24", Type: tt.taskType, Phase: tt.initialPhase},
+				},
+				logger: log.New(io.Discard, "", 0),
+			}
+
+			result := &agent.IterationResult{
+				AgentStatus: tt.agentStatus,
+				PRsCreated:  tt.prsCreated,
+			}
+
+			c.updateTaskPhase(taskID, result)
+
+			state := c.taskStates[taskID]
+			if state.Phase != tt.wantPhase {
+				t.Errorf("Phase = %q, want %q", state.Phase, tt.wantPhase)
+			}
+			if state.PRNumber != tt.wantPR {
+				t.Errorf("PRNumber = %q, want %q", state.PRNumber, tt.wantPR)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Add fallback in `updateTaskPhase()`: when no `AGENTIUM_STATUS` signal is present but PRs were detected in agent output, transition issue tasks to `PhaseComplete`
- Tighten PR detection regex to require "Created" or "Opened" verb, preventing issue references like "PR closes #24" from being misidentified as created PRs
- Extract `appendUnique` helper to deduplicate PR numbers across both text and URL detection patterns

## Problem

The controller kept iterating on the same task (issue #24) even after PR #110 was created, because the agent didn't emit `AGENTIUM_STATUS: PR_CREATED`. The overly broad regex also misidentified issue #24 and #9 as PRs.

## Test plan

- [x] New `TestUpdateTaskPhase_PRDetectionFallback` covers all fallback scenarios (issue vs PR task, with/without status signal, multiple PRs)
- [x] New `TestAdapter_ParseOutput_PRDetectionRegex` verifies tightened regex rejects bare issue refs, accepts real PR creation text, and deduplicates
- [x] Existing `TestAdapter_ParseOutput` cases still pass with updated regex
- [x] Full test suite passes (`go test ./...`)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)