### PR TITLE
Rewrite README with Ralph Wiggum loop branding and comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Agents run with `--dangerously-skip-permissions` (Claude Code's headless mode) o
 - **No lateral movement** — VMs have no access to other infrastructure
 - **Branch protection enforced** — Agents cannot commit directly to main/master
 
-### Dislaimer
-This application was entirely vibe-coded with Claude Code and some Codex review. A few issues were dogfooded through Agentium, and I expect that to be the long-term maintenance approach. Evals have been challenging until the full logging infrastructure is built, so the current state is likely to have some holes in it.
+### Disclaimer
+This application was entirely vibe-coded with Claude Code (with some Codex review). A number of issues have been dogfooded through Agentium itself, and that is the intended long-term maintenance approach. Evals have been difficult without the full logging infrastructure in place, so expect rough edges in the current state.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Restructures the README to lead with the Ralph Wiggum loop concept and controller-as-judge architecture
- Adds "Who Is This For?" section targeting CLI-comfortable agentic tool users
- Documents the full phase loop flow (PLAN → EVALUATE → IMPLEMENT → TEST → REVIEW → PR_CREATION) with configurable iteration limits
- Adds Safety and Security section explaining why `--dangerously-skip-permissions` is safe on ephemeral VMs
- Documents Claude Code authorization modes (API vs OAuth) with TOS considerations for credential copying
- Adds Limitations section covering dependency management, single-cloud, MacOS-only auth, and no mid-session feedback
- Adds Roadmap section derived from open issues
- References https://github.com/ghuntley/how-to-ralph-wiggum as architectural inspiration
- Updates architecture diagram to show phase loop within the controller

## Test plan

- [ ] Verify all internal links resolve correctly
- [ ] Confirm issue references (#103, #119, etc.) link to valid open issues
- [ ] Review rendering on GitHub (tables, code blocks, architecture diagram)
- [ ] Check that the how-to-ralph-wiggum external link is accessible

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)