### PR TITLE
Add --verbose flag to claude-code adapter command

### DIFF
--- a/internal/agent/claudecode/adapter.go
+++ b/internal/agent/claudecode/adapter.go
@@ -66,6 +66,7 @@ func (a *Adapter) BuildCommand(session *agent.Session, iteration int) []string {
 
 	args := []string{
 		"--print",
+		"--verbose",
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
 	}

--- a/internal/agent/claudecode/adapter_test.go
+++ b/internal/agent/claudecode/adapter_test.go
@@ -73,24 +73,28 @@ func TestAdapter_BuildCommand(t *testing.T) {
 
 	cmd := a.BuildCommand(session, 1)
 
-	if len(cmd) < 5 {
-		t.Fatalf("BuildCommand() returned %d args, want at least 5", len(cmd))
+	if len(cmd) < 6 {
+		t.Fatalf("BuildCommand() returned %d args, want at least 6", len(cmd))
 	}
 
 	if cmd[0] != "--print" {
 		t.Errorf("BuildCommand()[0] = %q, want %q", cmd[0], "--print")
 	}
 
-	if cmd[1] != "--output-format" {
-		t.Errorf("BuildCommand()[1] = %q, want %q", cmd[1], "--output-format")
+	if cmd[1] != "--verbose" {
+		t.Errorf("BuildCommand()[1] = %q, want %q", cmd[1], "--verbose")
 	}
 
-	if cmd[2] != "stream-json" {
-		t.Errorf("BuildCommand()[2] = %q, want %q", cmd[2], "stream-json")
+	if cmd[2] != "--output-format" {
+		t.Errorf("BuildCommand()[2] = %q, want %q", cmd[2], "--output-format")
 	}
 
-	if cmd[3] != "--dangerously-skip-permissions" {
-		t.Errorf("BuildCommand()[3] = %q, want %q", cmd[3], "--dangerously-skip-permissions")
+	if cmd[3] != "stream-json" {
+		t.Errorf("BuildCommand()[3] = %q, want %q", cmd[3], "stream-json")
+	}
+
+	if cmd[4] != "--dangerously-skip-permissions" {
+		t.Errorf("BuildCommand()[4] = %q, want %q", cmd[4], "--dangerously-skip-permissions")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `--verbose` flag to the claude-code adapter's `BuildCommand()` args, which is now required by Claude Code when using `--output-format=stream-json` with `--print`
- Updates tests to reflect the new argument position

## Context

Every iteration was failing with:
```
Iteration failed: When using --print, --output-format=stream-json requires --verbose
```

This caused sessions to burn through all 30 iterations retrying the same command without making progress.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/agent/claudecode/...` passes
- [ ] Run `agentium run` and verify iterations no longer fail with the stream-json error

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)