### PR TITLE
Generate valid phases list dynamically in routing warning

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -294,7 +294,7 @@ func New(config SessionConfig) (*Controller, error) {
 	}
 	if c.modelRouter.IsConfigured() {
 		if unknowns := c.modelRouter.UnknownPhases(); len(unknowns) > 0 {
-			c.logWarning("routing config references unknown phases: %v (valid: PLAN, IMPLEMENT, TEST, PR_CREATION, REVIEW, EVALUATE, ANALYZE, PUSH)", unknowns)
+			c.logWarning("routing config references unknown phases: %v (valid: %v)", unknowns, routing.ValidPhaseNames())
 		}
 		for _, name := range c.modelRouter.Adapters() {
 			if _, exists := c.adapters[name]; !exists {

--- a/internal/routing/types.go
+++ b/internal/routing/types.go
@@ -1,6 +1,9 @@
 package routing
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // ModelConfig specifies an adapter and model for a phase
 type ModelConfig struct {
@@ -27,6 +30,16 @@ var ValidPhases = map[string]bool{
 	"NOTHING_TO_DO": true,
 	"ANALYZE":      true,
 	"PUSH":         true,
+}
+
+// ValidPhaseNames returns the sorted list of recognized phase names.
+func ValidPhaseNames() []string {
+	names := make([]string, 0, len(ValidPhases))
+	for phase := range ValidPhases {
+		names = append(names, phase)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // ParseModelSpec parses an "adapter:model" colon-separated string into ModelConfig.


### PR DESCRIPTION
## Summary

- Adds `ValidPhaseNames()` function to the routing package that returns a sorted list of all valid phase names
- Replaces the hardcoded phase list in the controller warning with a dynamic call to `routing.ValidPhaseNames()`
- The old message listed only 8 of 11 valid phases (was missing COMPLETE, BLOCKED, NOTHING_TO_DO)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/routing/...` passes
- [x] `go test ./internal/controller/... -run Routing` passes — warning now shows all 11 phases

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)