### PR TITLE
Emit cloud logs during early controller lifecycle

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -429,7 +429,7 @@ func (c *Controller) Run(ctx context.Context) error {
 		c.issueDetails = issues
 	}
 
-	c.logInfo("Task queue: %d issues (%s), %d PRs", len(c.config.Tasks), strings.Join(c.config.Tasks, ", "), len(c.config.PRs))
+	c.logInfo("Task queue: %d issue(s) [%s], %d PR(s)", len(c.config.Tasks), strings.Join(c.config.Tasks, ", "), len(c.config.PRs))
 
 	// Main execution loop - processes tasks sequentially (PRs first, then issues)
 	for {
@@ -651,7 +651,7 @@ func (c *Controller) loadPrompts() error {
 	// Load project prompt from workspace (.agentium/AGENT.md)
 	projectPrompt, err := prompt.LoadProjectPrompt(c.workDir)
 	if err != nil {
-		c.logger.Printf("Warning: failed to load project prompt: %v", err)
+		c.logWarning("failed to load project prompt: %v", err)
 	} else if projectPrompt != "" {
 		c.projectPrompt = projectPrompt
 		c.logInfo("Project prompt loaded from .agentium/AGENT.md")


### PR DESCRIPTION
## Summary

- Convert early lifecycle log statements from `c.logger.Println/Printf` (stdout-only) to `c.logInfo()` (stdout + GCP Cloud Logging)
- Add `Version` variable set via ldflags at build time, with a "Controller started" log at the top of `Run()`
- Add task queue summary log after fetching issue/PR details

This ensures `agentium logs <session-id>` shows output immediately when the controller starts, rather than waiting until the first iteration completes.

Affected methods: `initializeWorkspace`, `fetchGitHubToken`, `cloneRepository`, `loadPrompts`, `fetchIssueDetails`, `fetchPRDetails`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy a test session and confirm `agentium logs <session-id>` shows lifecycle messages immediately

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)