### PR TITLE
Fix: Make --repo flag optional when set in .agentium.yaml

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -39,7 +39,6 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().String("repo", "", "GitHub repository (e.g., github.com/org/repo)")
-	runCmd.MarkFlagRequired("repo")
 	runCmd.Flags().StringSlice("issues", nil, "Issue numbers to work on (comma-separated)")
 	runCmd.Flags().StringSlice("prs", nil, "PR numbers to address review feedback (comma-separated)")
 	runCmd.Flags().String("agent", "claude-code", "Agent to use (claude-code, aider)")


### PR DESCRIPTION
## Summary

- Removes `runCmd.MarkFlagRequired("repo")` which caused Cobra to reject the command before config loading could provide the repository value from `.agentium.yaml`
- The existing validation at runtime already checks for an empty repository and returns a clear error message directing users to either use `--repo` or set it in config

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual: `agentium run --help` no longer shows `--repo` as `[required]`
- [x] Manual: `agentium run` with `project.repository` set in `.agentium.yaml` works without `--repo` flag

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)