### PR TITLE
Fix errcheck lint: check fmt.Scanln return value

### DIFF
--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -42,7 +42,11 @@ func destroySession(cmd *cobra.Command, args []string) error {
 		fmt.Print("Are you sure? [y/N]: ")
 
 		var confirm string
-		fmt.Scanln(&confirm)
+		if _, err := fmt.Scanln(&confirm); err != nil {
+			// Treat scan errors (e.g., EOF) as cancellation
+			fmt.Println("Cancelled.")
+			return nil
+		}
 		if confirm != "y" && confirm != "Y" {
 			fmt.Println("Cancelled.")
 			return nil


### PR DESCRIPTION
## Summary

- Fix unchecked `fmt.Scanln` return value in `internal/cli/destroy.go`
- Handle scan errors (e.g., EOF from piped input) as cancellation

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cli/...` passes
- [ ] CI lint check passes

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)