### PR TITLE
Trigger Docker workflow on workflow file changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/docker.yml"
       - "docker/**"
       - "cmd/**"
       - "internal/**"


### PR DESCRIPTION
## Summary

Add `.github/workflows/docker.yml` to its own paths filter so that changes to the workflow (like adding new agents to the matrix) will trigger a build.

Previously, changing the workflow file didn't trigger a build because only `docker/**`, `cmd/**`, `internal/**`, `go.mod`, and `go.sum` were in the paths filter.

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Merging this PR should trigger the Docker build workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)