### PR TITLE
Fix Docker agent build context to use repository root

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: docker/${{ matrix.agent }}
+          context: .
           file: docker/${{ matrix.agent }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

Fix the Docker build failure for agent images (claudecode, aider, codex) caused by incorrect build context.

### Root Cause

The agent Dockerfiles use COPY paths expecting the repository root:
```dockerfile
COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh
COPY docker/scripts/agent-wrapper.sh /runtime-scripts/agent-wrapper.sh
```

But the workflow was using `context: docker/${{ matrix.agent }}`, causing Docker to look for files at `docker/claudecode/docker/scripts/...` which doesn't exist.

### Fix

Changed the build context from `docker/${{ matrix.agent }}` to `.` (repository root), matching the controller job configuration.

Fixes #191

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] After merge, verify all three agent images build successfully:
  - `ghcr.io/andymwolf/agentium-claudecode:latest`
  - `ghcr.io/andymwolf/agentium-aider:latest`
  - `ghcr.io/andymwolf/agentium-codex:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)