### PR TITLE
Add bloat reduction issue templates

### DIFF
--- a/issues/001-duplicate-skill-files.md
+++ b/issues/001-duplicate-skill-files.md
@@ -1,0 +1,31 @@
+# Remove duplicate skill files in internal/skills
+
+## Problem
+
+`prompts/skills/` and `internal/skills/` contain 14 identical files plus a duplicate `manifest.yaml`, wasting ~5,500 tokens.
+
+### Identical files:
+- environment.md, implement.md, planning.md, pr_creation.md, pr_review.md, review.md, safety.md, status_signals.md, test.md, and 5 others
+- manifest.yaml (89 lines) exists in BOTH locations
+
+### Files with minor variations (4):
+- code_reviewer.md: 31 vs 27 lines
+- judge.md: 68 vs 52 lines (prompts has more detailed evaluation criteria)
+- plan.md: prompts version has extra "Scope Discipline" section
+- plan_reviewer.md: 27 vs 23 lines
+
+## Proposed Solution
+
+1. Delete `internal/skills/` directory entirely
+2. Keep `prompts/skills/` as the source of truth
+3. Merge the 4 differing files (prompts versions are more complete)
+4. Update code imports to reference `prompts/skills/`
+
+## Impact
+
+- **Token savings:** ~5,500 tokens
+- **Effort:** Medium
+- **Risk:** Low - just consolidation
+
+## Labels
+bloat-reduction, documentation

--- a/issues/002-duplicate-system-md.md
+++ b/issues/002-duplicate-system-md.md
@@ -1,0 +1,29 @@
+# Consolidate duplicate SYSTEM.md prompt files
+
+## Problem
+
+Two near-identical system prompt files exist, wasting ~1,325 tokens:
+- `/prompts/SYSTEM.md` (374 lines, 13.6 KB)
+- `/internal/prompt/system.md` (321 lines, 11.7 KB)
+
+### Key Differences
+The prompts version contains ~52 extra lines:
+- "SCOPE DISCIPLINE" section (14 lines on avoiding scope creep)
+- "COMMIT DISCIPLINE" section (13 lines on validation before commits)
+
+## Proposed Solution
+
+1. Keep `/prompts/SYSTEM.md` as the authoritative version (it's more complete)
+2. Update code to load from single location
+3. Either:
+   - Remove `internal/prompt/system.md` entirely, OR
+   - Replace with symlink/embed reference to prompts version
+
+## Impact
+
+- **Token savings:** ~1,325 tokens
+- **Effort:** Low
+- **Risk:** Low - need to verify code references
+
+## Labels
+bloat-reduction, documentation

--- a/issues/003-readme-docs-overlap.md
+++ b/issues/003-readme-docs-overlap.md
@@ -1,0 +1,32 @@
+# Reduce README/getting-started.md documentation overlap
+
+## Problem
+
+`README.md` (358 lines) and `docs/getting-started.md` (220 lines) contain significant overlapping content, wasting ~1,500 tokens.
+
+### Overlapping Content
+Both files cover:
+- "How It Works" architecture explanation
+- "Ralph Wiggum Loop" concept
+- Prerequisites
+- Installation steps
+- Quick Start guide
+
+## Proposed Solution
+
+1. Convert `README.md` to a concise landing page (max 100-150 lines):
+   - Brief project description
+   - Key features (bulleted)
+   - Links to detailed docs
+   - Badge/status info
+2. Move all detailed getting-started content to `docs/getting-started.md`
+3. Ensure single source of truth for each concept
+
+## Impact
+
+- **Token savings:** ~1,500 tokens
+- **Effort:** Medium
+- **Risk:** Low - documentation only
+
+## Labels
+bloat-reduction, documentation

--- a/issues/004-verbose-system-prompt.md
+++ b/issues/004-verbose-system-prompt.md
@@ -1,0 +1,28 @@
+# Refactor verbose SYSTEM.md prompt for conciseness
+
+## Problem
+
+`/prompts/SYSTEM.md` (374 lines) contains excessive verbosity and repetition, wasting ~2,000 tokens that could be reduced without losing clarity.
+
+### Issues Identified
+- "Mandatory" rules repeated throughout multiple sections
+- Same concepts explained 3-4 different ways
+- Long prose examples that could be checklists
+- Multiple similar sections on error handling and commit discipline
+
+## Proposed Solution
+
+1. Extract repetitive "mandatory rules" to a single section, reference elsewhere
+2. Consolidate related rule sections (e.g., all "discipline" rules together)
+3. Convert verbose examples to brief checklist format
+4. Use reference links for repetitive concepts
+5. Target: reduce from ~374 lines to ~200 lines
+
+## Impact
+
+- **Token savings:** ~2,000 tokens
+- **Effort:** Low-Medium
+- **Risk:** Low - must preserve meaning while reducing verbosity
+
+## Labels
+bloat-reduction, documentation

--- a/issues/005-agent-instruction-redundancy.md
+++ b/issues/005-agent-instruction-redundancy.md
@@ -1,0 +1,33 @@
+# Consolidate redundant agent instruction files
+
+## Problem
+
+Three files contain overlapping agent instructions, wasting ~800 tokens:
+- `/CLAUDE.md` (121 lines)
+- `/.claude/skills/agentium/SKILL.md` (267 lines)
+- `/.agentium/AGENT.md` (72 lines)
+
+### Overlapping Content
+All three cover:
+- Branch naming conventions
+- Commit message format
+- Testing requirements
+- Workflow rules
+
+`SKILL.md` appears to be the most comprehensive version.
+
+## Proposed Solution
+
+1. Keep `SKILL.md` as the authoritative source (most complete)
+2. Minimize `CLAUDE.md` to essential entry-point info only, reference SKILL.md
+3. Evaluate if `AGENT.md` is needed or can be removed/consolidated
+4. Ensure no instruction drift between files
+
+## Impact
+
+- **Token savings:** ~800 tokens
+- **Effort:** Low
+- **Risk:** Low - need to verify which file is loaded by tooling
+
+## Labels
+bloat-reduction, documentation

--- a/issues/006-cloud-docs-boilerplate.md
+++ b/issues/006-cloud-docs-boilerplate.md
@@ -1,0 +1,34 @@
+# Extract common content from cloud setup documentation
+
+## Problem
+
+Cloud setup docs share ~40% common content across providers, wasting ~1,500 tokens:
+- `docs/cloud-setup/aws.md` (~240 lines)
+- `docs/cloud-setup/azure.md` (~240 lines)
+- `docs/cloud-setup/gcp.md` (~230 lines)
+
+### Shared Content
+- Prerequisites sections
+- Authentication concepts
+- General workflow steps
+- Common troubleshooting
+
+## Proposed Solution
+
+1. Create `docs/cloud-setup/COMMON.md` with shared content:
+   - General prerequisites
+   - Authentication overview
+   - Common workflow steps
+   - Shared troubleshooting
+2. Update provider-specific docs to reference common content
+3. Keep only provider-specific details in aws.md, azure.md, gcp.md
+4. Target: reduce each file from ~240 lines to ~150 lines
+
+## Impact
+
+- **Token savings:** ~1,500 tokens
+- **Effort:** Low-Medium
+- **Risk:** Low - documentation only
+
+## Labels
+bloat-reduction, documentation

--- a/issues/007-claudeignore.md
+++ b/issues/007-claudeignore.md
@@ -1,0 +1,41 @@
+# Add .claudeignore to exclude non-essential files from context
+
+## Problem
+
+When Claude loads the repository context, it includes files that aren't useful for most tasks, consuming valuable context window space.
+
+### Files to Exclude
+- `go.sum` (~14,000 tokens) - auto-generated, rarely needed
+- Generated files and build artifacts
+- Verbose documentation that's rarely referenced
+- Test fixtures and mock data files
+- Vendor directories (if any)
+
+## Proposed Solution
+
+1. Create `.claudeignore` file at repository root
+2. Add patterns for:
+   ```
+   go.sum
+   *.pb.go
+   *_generated.go
+   vendor/
+   .git/
+   *.test
+   testdata/
+   ```
+3. Document the file's purpose in a comment header
+
+## Impact
+
+- **Token savings:** ~15,000+ tokens (context-specific)
+- **Effort:** Low
+- **Risk:** None - only affects Claude context loading
+
+## Acceptance Criteria
+- [ ] `.claudeignore` file created
+- [ ] Tested that Claude respects the ignore patterns
+- [ ] Documented in CLAUDE.md or README
+
+## Labels
+developer-experience, tooling

--- a/issues/008-project-summary-file.md
+++ b/issues/008-project-summary-file.md
@@ -1,0 +1,53 @@
+# Create condensed project summary file for Claude context
+
+## Problem
+
+Claude currently needs to read multiple files to understand the project structure and key concepts. A condensed summary would provide faster context loading and leave more room for actual work.
+
+## Proposed Solution
+
+1. Create `PROJECT_SUMMARY.md` (or similar) containing:
+   - Project architecture overview (condensed)
+   - Key file locations and their purposes
+   - Important patterns and conventions
+   - Quick reference for common tasks
+   - Links to detailed docs for deep dives
+
+2. Target size: 200-300 lines max (~750-1000 tokens)
+
+3. Structure:
+   ```markdown
+   # Agentium Project Summary
+
+   ## Architecture
+   [Brief overview with key components]
+
+   ## Key Files
+   | Path | Purpose |
+   |------|---------|
+   | cmd/agentium/ | CLI entry point |
+   | ... | ... |
+
+   ## Patterns
+   - Error handling: [brief]
+   - Testing: [brief]
+
+   ## Common Tasks
+   - Build: `go build ./...`
+   - Test: `go test ./...`
+   ```
+
+## Impact
+
+- **Token savings:** Indirect - allows Claude to load summary instead of full files
+- **Effort:** Medium
+- **Risk:** None - additive improvement
+
+## Acceptance Criteria
+- [ ] Summary file created
+- [ ] Covers all key project aspects
+- [ ] Under 300 lines
+- [ ] Referenced in CLAUDE.md for discoverability
+
+## Labels
+developer-experience, documentation

--- a/issues/009-modularize-skill-prompts.md
+++ b/issues/009-modularize-skill-prompts.md
@@ -1,0 +1,54 @@
+# Modularize skill prompts for on-demand loading
+
+## Problem
+
+Currently all skill prompts may be loaded together, consuming context space even when only specific skills are needed for a task.
+
+### Current State
+- 18+ skill files in `prompts/skills/`
+- Total: ~5,500 tokens for all skills
+- Many tasks only need 1-3 specific skills
+
+## Proposed Solution
+
+1. **Implement lazy loading** - only load skill prompts when needed
+2. **Create skill manifest** with metadata:
+   ```yaml
+   skills:
+     - name: implement
+       file: implement.md
+       triggers: ["implement", "code", "build"]
+       tokens: ~300
+     - name: test
+       file: test.md
+       triggers: ["test", "verify"]
+       tokens: ~250
+   ```
+3. **Add skill selection logic** - determine required skills based on task
+4. **Cache loaded skills** - avoid reloading within same session
+
+## Implementation Options
+
+### Option A: Controller-level loading
+Load skills in controller based on phase/task type
+
+### Option B: Prompt composition
+Build prompts dynamically with only needed skills
+
+### Option C: Include directives
+Use include syntax in prompts, resolve at runtime
+
+## Impact
+
+- **Token savings:** ~3,000-4,000 tokens per typical task
+- **Effort:** Medium-High
+- **Risk:** Medium - requires code changes to prompt loading
+
+## Acceptance Criteria
+- [ ] Skills loaded on-demand based on task
+- [ ] Manifest defines skill metadata
+- [ ] No functionality regression
+- [ ] Documented skill loading behavior
+
+## Labels
+enhancement, performance


### PR DESCRIPTION
9 issues for reducing repository token count:
1. Duplicate skill files (~5,500 tokens)
2. Duplicate SYSTEM.md (~1,325 tokens)
3. README/docs overlap (~1,500 tokens)
4. Verbose system prompt (~2,000 tokens)
5. Agent instruction redundancy (~800 tokens)
6. Cloud docs boilerplate (~1,500 tokens)
7. Add .claudeignore (~15,000 tokens)
8. Project summary file
9. Modularize skill prompts

Co-Authored-By: Claude <noreply@anthropic.com>