### PR TITLE
Add handoff package for sub-agents context minimization model

### DIFF
--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -12,7 +12,8 @@ type ExistingWork struct {
 type IterationContext struct {
 	Phase         string // e.g., "IMPLEMENT", "TEST"
 	SkillsPrompt  string // Composed from phase-relevant skills
-	MemoryContext string // Summarized memory from previous iterations
+	MemoryContext string // Summarized memory from previous iterations (legacy)
+	PhaseInput    string // Structured input for sub-agents model (replaces MemoryContext when handoff enabled)
 	ModelOverride string // Model ID to pass as --model flag to the agent CLI
 	Iteration     int    // Current iteration number
 	SubTaskID     string // Unique ID for delegation tracking
@@ -52,6 +53,7 @@ type IterationResult struct {
 	TokensUsed     int
 	Events         []interface{} `json:"-"` // Structured events (type-assert per adapter)
 	RawTextContent string        `json:"-"` // Aggregated text from structured output
+	HandoffOutput  string        `json:"-"` // Raw JSON from AGENTIUM_HANDOFF signal (sub-agents model)
 }
 
 // Agent defines the interface that all agent adapters must implement

--- a/internal/handoff/builders.go
+++ b/internal/handoff/builders.go
@@ -1,0 +1,346 @@
+package handoff
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// BuildPlanInput constructs the input for the PLAN phase.
+// This is the minimal context needed for planning: just the issue details.
+func BuildPlanInput(issueCtx *IssueContext) (string, error) {
+	if issueCtx == nil {
+		return "", fmt.Errorf("issue context is required for PLAN phase")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Issue Context\n\n")
+	sb.WriteString(fmt.Sprintf("**Repository:** %s\n", issueCtx.Repository))
+	sb.WriteString(fmt.Sprintf("**Issue:** #%s\n", issueCtx.Number))
+	sb.WriteString(fmt.Sprintf("**Title:** %s\n\n", issueCtx.Title))
+
+	if issueCtx.Body != "" {
+		sb.WriteString("**Description:**\n")
+		sb.WriteString(issueCtx.Body)
+		sb.WriteString("\n\n")
+	}
+
+	return sb.String(), nil
+}
+
+// BuildImplementInput constructs the input for the IMPLEMENT phase.
+// This includes the issue context, the plan, and any existing work.
+func BuildImplementInput(store *Store, taskID string, existingWork *ExistingWorkContext) (string, error) {
+	issueCtx := store.GetIssueContext(taskID)
+	if issueCtx == nil {
+		return "", fmt.Errorf("issue context not found for task %s", taskID)
+	}
+
+	plan := store.GetPlanOutput(taskID)
+	if plan == nil {
+		return "", fmt.Errorf("plan output not found for task %s", taskID)
+	}
+
+	var sb strings.Builder
+
+	// Issue summary (minimal)
+	sb.WriteString("## Task\n\n")
+	sb.WriteString(fmt.Sprintf("**Issue #%s:** %s\n\n", issueCtx.Number, issueCtx.Title))
+
+	// Plan from previous phase
+	sb.WriteString("## Implementation Plan\n\n")
+	sb.WriteString(fmt.Sprintf("**Summary:** %s\n\n", plan.Summary))
+
+	if len(plan.FilesToModify) > 0 {
+		sb.WriteString("**Files to modify:**\n")
+		for _, f := range plan.FilesToModify {
+			sb.WriteString(fmt.Sprintf("- %s\n", f))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(plan.FilesToCreate) > 0 {
+		sb.WriteString("**Files to create:**\n")
+		for _, f := range plan.FilesToCreate {
+			sb.WriteString(fmt.Sprintf("- %s\n", f))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(plan.ImplementationSteps) > 0 {
+		sb.WriteString("**Implementation steps:**\n")
+		for _, step := range plan.ImplementationSteps {
+			if step.File != "" {
+				sb.WriteString(fmt.Sprintf("%d. %s (in %s)\n", step.Number, step.Description, step.File))
+			} else {
+				sb.WriteString(fmt.Sprintf("%d. %s\n", step.Number, step.Description))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("**Testing approach:** %s\n\n", plan.TestingApproach))
+
+	// Existing work context
+	if existingWork != nil {
+		sb.WriteString("## Existing Work\n\n")
+		if existingWork.PRNumber != "" {
+			sb.WriteString(fmt.Sprintf("An existing PR #%s exists on branch `%s`.\n", existingWork.PRNumber, existingWork.Branch))
+			sb.WriteString("Check out this branch and continue from where it left off.\n\n")
+		} else if existingWork.Branch != "" {
+			sb.WriteString(fmt.Sprintf("An existing branch `%s` exists.\n", existingWork.Branch))
+			sb.WriteString("Check out this branch and continue from where it left off.\n\n")
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// BuildReviewInput constructs the input for the REVIEW phase.
+// This includes the plan summary and implementation output.
+func BuildReviewInput(store *Store, taskID string) (string, error) {
+	issueCtx := store.GetIssueContext(taskID)
+	if issueCtx == nil {
+		return "", fmt.Errorf("issue context not found for task %s", taskID)
+	}
+
+	plan := store.GetPlanOutput(taskID)
+	if plan == nil {
+		return "", fmt.Errorf("plan output not found for task %s", taskID)
+	}
+
+	impl := store.GetImplementOutput(taskID)
+	if impl == nil {
+		return "", fmt.Errorf("implement output not found for task %s", taskID)
+	}
+
+	var sb strings.Builder
+
+	// Issue summary (minimal)
+	sb.WriteString("## Task\n\n")
+	sb.WriteString(fmt.Sprintf("**Issue #%s:** %s\n\n", issueCtx.Number, issueCtx.Title))
+
+	// Plan summary (not full plan - just what reviewer needs)
+	sb.WriteString("## Plan Summary\n\n")
+	sb.WriteString(plan.Summary)
+	sb.WriteString("\n\n")
+
+	// Implementation output
+	sb.WriteString("## Implementation Completed\n\n")
+	sb.WriteString(fmt.Sprintf("**Branch:** %s\n", impl.BranchName))
+
+	if len(impl.FilesChanged) > 0 {
+		sb.WriteString(fmt.Sprintf("**Files changed:** %d\n", len(impl.FilesChanged)))
+		for _, f := range impl.FilesChanged {
+			sb.WriteString(fmt.Sprintf("- %s\n", f))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(impl.Commits) > 0 {
+		sb.WriteString(fmt.Sprintf("**Commits:** %d\n", len(impl.Commits)))
+		for _, c := range impl.Commits {
+			sb.WriteString(fmt.Sprintf("- %s: %s\n", c.SHA[:7], c.Message))
+		}
+		sb.WriteString("\n")
+	}
+
+	if impl.TestsPassed {
+		sb.WriteString("**Tests:** Passed\n\n")
+	} else {
+		sb.WriteString("**Tests:** Failed or not run\n")
+		if impl.TestOutput != "" {
+			sb.WriteString("```\n")
+			// Truncate test output to avoid bloat
+			output := impl.TestOutput
+			if len(output) > 1000 {
+				output = output[:1000] + "\n... (truncated)"
+			}
+			sb.WriteString(output)
+			sb.WriteString("\n```\n\n")
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// BuildDocsInput constructs the input for the DOCS phase.
+// This includes what files were changed for doc update context.
+func BuildDocsInput(store *Store, taskID string) (string, error) {
+	issueCtx := store.GetIssueContext(taskID)
+	if issueCtx == nil {
+		return "", fmt.Errorf("issue context not found for task %s", taskID)
+	}
+
+	plan := store.GetPlanOutput(taskID)
+	if plan == nil {
+		return "", fmt.Errorf("plan output not found for task %s", taskID)
+	}
+
+	impl := store.GetImplementOutput(taskID)
+	if impl == nil {
+		return "", fmt.Errorf("implement output not found for task %s", taskID)
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("## Task\n\n")
+	sb.WriteString(fmt.Sprintf("**Issue #%s:** %s\n\n", issueCtx.Number, issueCtx.Title))
+
+	sb.WriteString("## Summary\n\n")
+	sb.WriteString(plan.Summary)
+	sb.WriteString("\n\n")
+
+	sb.WriteString("## Files Changed\n\n")
+	for _, f := range impl.FilesChanged {
+		sb.WriteString(fmt.Sprintf("- %s\n", f))
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString("## Instructions\n\n")
+	sb.WriteString("Review if any documentation needs to be updated based on the changes above.\n")
+	sb.WriteString("If no documentation changes are needed, emit an empty docs output.\n")
+
+	return sb.String(), nil
+}
+
+// BuildPRCreationInput constructs the input for the PR_CREATION phase.
+func BuildPRCreationInput(store *Store, taskID string) (string, error) {
+	issueCtx := store.GetIssueContext(taskID)
+	if issueCtx == nil {
+		return "", fmt.Errorf("issue context not found for task %s", taskID)
+	}
+
+	plan := store.GetPlanOutput(taskID)
+	if plan == nil {
+		return "", fmt.Errorf("plan output not found for task %s", taskID)
+	}
+
+	impl := store.GetImplementOutput(taskID)
+	if impl == nil {
+		return "", fmt.Errorf("implement output not found for task %s", taskID)
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("## Create Pull Request\n\n")
+	sb.WriteString(fmt.Sprintf("**Issue:** #%s - %s\n", issueCtx.Number, issueCtx.Title))
+	sb.WriteString(fmt.Sprintf("**Branch:** %s\n", impl.BranchName))
+	sb.WriteString(fmt.Sprintf("**Files changed:** %d\n", len(impl.FilesChanged)))
+
+	if impl.TestsPassed {
+		sb.WriteString("**Tests:** Passed\n\n")
+	} else {
+		sb.WriteString("**Tests:** Not passed (PR should note this)\n\n")
+	}
+
+	sb.WriteString("## Summary for PR Description\n\n")
+	sb.WriteString(plan.Summary)
+	sb.WriteString("\n\n")
+
+	sb.WriteString("## Instructions\n\n")
+	sb.WriteString("1. Push the branch if not already pushed\n")
+	sb.WriteString(fmt.Sprintf("2. Create a PR with title referencing issue #%s\n", issueCtx.Number))
+	sb.WriteString(fmt.Sprintf("3. Include 'Closes #%s' in the PR body\n", issueCtx.Number))
+	sb.WriteString("4. Emit the PR number and URL in the handoff output\n")
+
+	return sb.String(), nil
+}
+
+// BuildInputForPhase constructs the input string for the given phase.
+// Returns the input content and any error.
+func BuildInputForPhase(store *Store, taskID string, phase string, existingWork *ExistingWorkContext) (string, error) {
+	switch phase {
+	case "PLAN":
+		issueCtx := store.GetIssueContext(taskID)
+		return BuildPlanInput(issueCtx)
+	case "IMPLEMENT":
+		return BuildImplementInput(store, taskID, existingWork)
+	case "REVIEW":
+		return BuildReviewInput(store, taskID)
+	case "DOCS":
+		return BuildDocsInput(store, taskID)
+	case "PR_CREATION":
+		return BuildPRCreationInput(store, taskID)
+	default:
+		return "", fmt.Errorf("unknown phase: %s", phase)
+	}
+}
+
+// BuildInputForPhaseJSON constructs a JSON representation of the phase input.
+// Useful for structured injection into agent prompts.
+func BuildInputForPhaseJSON(store *Store, taskID string, phase string, existingWork *ExistingWorkContext) (string, error) {
+	var input interface{}
+
+	switch phase {
+	case "PLAN":
+		issueCtx := store.GetIssueContext(taskID)
+		if issueCtx == nil {
+			return "", fmt.Errorf("issue context not found for task %s", taskID)
+		}
+		input = issueCtx
+
+	case "IMPLEMENT":
+		issueCtx := store.GetIssueContext(taskID)
+		plan := store.GetPlanOutput(taskID)
+		if issueCtx == nil || plan == nil {
+			return "", fmt.Errorf("missing required data for IMPLEMENT phase")
+		}
+		input = ImplementInput{
+			IssueContext: *issueCtx,
+			Plan:         *plan,
+			ExistingWork: existingWork,
+		}
+
+	case "REVIEW":
+		issueCtx := store.GetIssueContext(taskID)
+		plan := store.GetPlanOutput(taskID)
+		impl := store.GetImplementOutput(taskID)
+		if issueCtx == nil || plan == nil || impl == nil {
+			return "", fmt.Errorf("missing required data for REVIEW phase")
+		}
+		input = ReviewInput{
+			IssueContext:   *issueCtx,
+			PlanSummary:    plan.Summary,
+			Implementation: *impl,
+		}
+
+	case "DOCS":
+		issueCtx := store.GetIssueContext(taskID)
+		plan := store.GetPlanOutput(taskID)
+		impl := store.GetImplementOutput(taskID)
+		if issueCtx == nil || plan == nil || impl == nil {
+			return "", fmt.Errorf("missing required data for DOCS phase")
+		}
+		input = DocsInput{
+			IssueContext: *issueCtx,
+			PlanSummary:  plan.Summary,
+			FilesChanged: impl.FilesChanged,
+		}
+
+	case "PR_CREATION":
+		issueCtx := store.GetIssueContext(taskID)
+		plan := store.GetPlanOutput(taskID)
+		impl := store.GetImplementOutput(taskID)
+		if issueCtx == nil || plan == nil || impl == nil {
+			return "", fmt.Errorf("missing required data for PR_CREATION phase")
+		}
+		input = PRCreationInput{
+			IssueContext: *issueCtx,
+			BranchName:   impl.BranchName,
+			PlanSummary:  plan.Summary,
+			FilesChanged: impl.FilesChanged,
+			TestsPassed:  impl.TestsPassed,
+			TestOutput:   impl.TestOutput,
+		}
+
+	default:
+		return "", fmt.Errorf("unknown phase: %s", phase)
+	}
+
+	data, err := json.MarshalIndent(input, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal phase input: %w", err)
+	}
+	return string(data), nil
+}

--- a/internal/handoff/builders_test.go
+++ b/internal/handoff/builders_test.go
@@ -1,0 +1,236 @@
+package handoff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPlanInput(t *testing.T) {
+	ctx := &IssueContext{
+		Number:     "42",
+		Title:      "Add authentication",
+		Body:       "Implement OAuth2 login",
+		Repository: "owner/repo",
+	}
+
+	input, err := BuildPlanInput(ctx)
+	if err != nil {
+		t.Fatalf("BuildPlanInput() error = %v", err)
+	}
+
+	if !strings.Contains(input, "Repository:** owner/repo") {
+		t.Error("input should contain repository")
+	}
+	if !strings.Contains(input, "Issue:** #42") {
+		t.Error("input should contain issue number")
+	}
+	if !strings.Contains(input, "Title:** Add authentication") {
+		t.Error("input should contain title")
+	}
+	if !strings.Contains(input, "OAuth2 login") {
+		t.Error("input should contain body")
+	}
+}
+
+func TestBuildPlanInput_NilContext(t *testing.T) {
+	_, err := BuildPlanInput(nil)
+	if err == nil {
+		t.Error("expected error for nil context")
+	}
+}
+
+func TestBuildImplementInput(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	store.SetIssueContext(taskID, &IssueContext{
+		Number: "42",
+		Title:  "Add feature",
+	})
+	store.SetPlanOutput(taskID, &PlanOutput{
+		Summary:       "Add the feature",
+		FilesToModify: []string{"main.go"},
+		FilesToCreate: []string{"feature.go"},
+		ImplementationSteps: []ImplementationStep{
+			{Number: 1, Description: "Create file", File: "feature.go"},
+			{Number: 2, Description: "Update main"},
+		},
+		TestingApproach: "Unit tests",
+	})
+
+	input, err := BuildImplementInput(store, taskID, nil)
+	if err != nil {
+		t.Fatalf("BuildImplementInput() error = %v", err)
+	}
+
+	if !strings.Contains(input, "Issue #42") {
+		t.Error("input should contain issue number")
+	}
+	if !strings.Contains(input, "Add the feature") {
+		t.Error("input should contain plan summary")
+	}
+	if !strings.Contains(input, "main.go") {
+		t.Error("input should contain files to modify")
+	}
+	if !strings.Contains(input, "feature.go") {
+		t.Error("input should contain files to create")
+	}
+	if !strings.Contains(input, "Create file") {
+		t.Error("input should contain implementation steps")
+	}
+}
+
+func TestBuildImplementInput_WithExistingWork(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	store.SetIssueContext(taskID, &IssueContext{Number: "42", Title: "Test"})
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "test"})
+
+	existingWork := &ExistingWorkContext{
+		Branch:   "agentium/issue-42-test",
+		PRNumber: "123",
+		PRTitle:  "Test PR",
+	}
+
+	input, err := BuildImplementInput(store, taskID, existingWork)
+	if err != nil {
+		t.Fatalf("BuildImplementInput() error = %v", err)
+	}
+
+	if !strings.Contains(input, "Existing Work") {
+		t.Error("input should contain existing work section")
+	}
+	if !strings.Contains(input, "PR #123") {
+		t.Error("input should contain PR number")
+	}
+	if !strings.Contains(input, "agentium/issue-42-test") {
+		t.Error("input should contain branch name")
+	}
+}
+
+func TestBuildReviewInput(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	store.SetIssueContext(taskID, &IssueContext{Number: "42", Title: "Test"})
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "Test plan summary"})
+	store.SetImplementOutput(taskID, &ImplementOutput{
+		BranchName: "agentium/issue-42-test",
+		FilesChanged: []string{"file1.go", "file2.go"},
+		Commits: []CommitInfo{
+			{SHA: "abc1234567890", Message: "Add feature"},
+		},
+		TestsPassed: true,
+	})
+
+	input, err := BuildReviewInput(store, taskID)
+	if err != nil {
+		t.Fatalf("BuildReviewInput() error = %v", err)
+	}
+
+	if !strings.Contains(input, "Issue #42") {
+		t.Error("input should contain issue number")
+	}
+	if !strings.Contains(input, "Test plan summary") {
+		t.Error("input should contain plan summary")
+	}
+	if !strings.Contains(input, "agentium/issue-42-test") {
+		t.Error("input should contain branch name")
+	}
+	if !strings.Contains(input, "file1.go") {
+		t.Error("input should contain changed files")
+	}
+	if !strings.Contains(input, "abc1234") {
+		t.Error("input should contain commit SHA (truncated)")
+	}
+	if !strings.Contains(input, "Passed") {
+		t.Error("input should indicate tests passed")
+	}
+}
+
+func TestBuildPRCreationInput(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	store.SetIssueContext(taskID, &IssueContext{
+		Number: "42",
+		Title:  "Add feature",
+	})
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "Plan summary"})
+	store.SetImplementOutput(taskID, &ImplementOutput{
+		BranchName:   "agentium/issue-42-feature",
+		FilesChanged: []string{"main.go", "feature.go"},
+		TestsPassed:  true,
+	})
+
+	input, err := BuildPRCreationInput(store, taskID)
+	if err != nil {
+		t.Fatalf("BuildPRCreationInput() error = %v", err)
+	}
+
+	if !strings.Contains(input, "#42") {
+		t.Error("input should contain issue number")
+	}
+	if !strings.Contains(input, "agentium/issue-42-feature") {
+		t.Error("input should contain branch name")
+	}
+	if !strings.Contains(input, "Closes #42") {
+		t.Error("input should mention closing issue")
+	}
+}
+
+func TestBuildInputForPhase(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	store.SetIssueContext(taskID, &IssueContext{Number: "42", Title: "Test"})
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "plan"})
+	store.SetImplementOutput(taskID, &ImplementOutput{BranchName: "branch"})
+
+	tests := []struct {
+		phase     string
+		shouldErr bool
+	}{
+		{"PLAN", false},
+		{"IMPLEMENT", false},
+		{"REVIEW", false},
+		{"DOCS", false},
+		{"PR_CREATION", false},
+		{"UNKNOWN", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			_, err := BuildInputForPhase(store, taskID, tt.phase, nil)
+			if (err != nil) != tt.shouldErr {
+				t.Errorf("BuildInputForPhase(%s) error = %v, shouldErr = %v", tt.phase, err, tt.shouldErr)
+			}
+		})
+	}
+}
+
+func TestBuildInputForPhaseJSON(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	store.SetIssueContext(taskID, &IssueContext{Number: "42", Title: "Test"})
+
+	json, err := BuildInputForPhaseJSON(store, taskID, "PLAN", nil)
+	if err != nil {
+		t.Fatalf("BuildInputForPhaseJSON() error = %v", err)
+	}
+
+	if !strings.Contains(json, `"number": "42"`) {
+		t.Error("JSON should contain issue number")
+	}
+	if !strings.Contains(json, `"title": "Test"`) {
+		t.Error("JSON should contain title")
+	}
+}

--- a/internal/handoff/parser.go
+++ b/internal/handoff/parser.go
@@ -1,0 +1,223 @@
+package handoff
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Signal prefix for structured handoff output
+const HandoffSignalPrefix = "AGENTIUM_HANDOFF:"
+
+// handoffPattern matches AGENTIUM_HANDOFF: followed by JSON
+// The JSON can span multiple lines, so we capture everything after the prefix
+// until we find a complete JSON object.
+var handoffPattern = regexp.MustCompile(`AGENTIUM_HANDOFF:\s*(\{[\s\S]*?\})(?:\s*$|\s*\n)`)
+
+// ParsedHandoff contains the parsed handoff data and metadata about the parse.
+type ParsedHandoff struct {
+	Phase   string // Phase that produced this handoff (inferred from content)
+	RawJSON string // The raw JSON string that was parsed
+}
+
+// ParseHandoffSignal extracts and parses an AGENTIUM_HANDOFF signal from agent output.
+// Returns the raw JSON string and any error.
+func ParseHandoffSignal(output string) (string, error) {
+	// Look for the signal prefix
+	idx := strings.Index(output, HandoffSignalPrefix)
+	if idx == -1 {
+		return "", fmt.Errorf("no AGENTIUM_HANDOFF signal found in output")
+	}
+
+	// Extract everything after the prefix
+	remainder := output[idx+len(HandoffSignalPrefix):]
+	remainder = strings.TrimSpace(remainder)
+
+	// Find the JSON object - it should start with {
+	if !strings.HasPrefix(remainder, "{") {
+		return "", fmt.Errorf("AGENTIUM_HANDOFF signal not followed by JSON object")
+	}
+
+	// Parse the JSON to find where it ends
+	jsonStr, err := extractJSONObject(remainder)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract JSON from AGENTIUM_HANDOFF: %w", err)
+	}
+
+	return jsonStr, nil
+}
+
+// extractJSONObject extracts a complete JSON object from a string that starts with {.
+// It handles nested objects and arrays properly.
+func extractJSONObject(s string) (string, error) {
+	if len(s) == 0 || s[0] != '{' {
+		return "", fmt.Errorf("string does not start with {")
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i, c := range s {
+		if escaped {
+			escaped = false
+			continue
+		}
+
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+
+		if inString {
+			continue
+		}
+
+		if c == '{' {
+			depth++
+		} else if c == '}' {
+			depth--
+			if depth == 0 {
+				return s[:i+1], nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("incomplete JSON object")
+}
+
+// ParsePlanOutput parses a PlanOutput from raw JSON.
+func ParsePlanOutput(jsonStr string) (*PlanOutput, error) {
+	var output PlanOutput
+	if err := json.Unmarshal([]byte(jsonStr), &output); err != nil {
+		return nil, fmt.Errorf("failed to parse PlanOutput: %w", err)
+	}
+	return &output, nil
+}
+
+// ParseImplementOutput parses an ImplementOutput from raw JSON.
+func ParseImplementOutput(jsonStr string) (*ImplementOutput, error) {
+	var output ImplementOutput
+	if err := json.Unmarshal([]byte(jsonStr), &output); err != nil {
+		return nil, fmt.Errorf("failed to parse ImplementOutput: %w", err)
+	}
+	return &output, nil
+}
+
+// ParseReviewOutput parses a ReviewOutput from raw JSON.
+func ParseReviewOutput(jsonStr string) (*ReviewOutput, error) {
+	var output ReviewOutput
+	if err := json.Unmarshal([]byte(jsonStr), &output); err != nil {
+		return nil, fmt.Errorf("failed to parse ReviewOutput: %w", err)
+	}
+	return &output, nil
+}
+
+// ParseDocsOutput parses a DocsOutput from raw JSON.
+func ParseDocsOutput(jsonStr string) (*DocsOutput, error) {
+	var output DocsOutput
+	if err := json.Unmarshal([]byte(jsonStr), &output); err != nil {
+		return nil, fmt.Errorf("failed to parse DocsOutput: %w", err)
+	}
+	return &output, nil
+}
+
+// ParsePRCreationOutput parses a PRCreationOutput from raw JSON.
+func ParsePRCreationOutput(jsonStr string) (*PRCreationOutput, error) {
+	var output PRCreationOutput
+	if err := json.Unmarshal([]byte(jsonStr), &output); err != nil {
+		return nil, fmt.Errorf("failed to parse PRCreationOutput: %w", err)
+	}
+	return &output, nil
+}
+
+// ParseAndStorePhaseOutput parses the AGENTIUM_HANDOFF signal from agent output
+// and stores it in the handoff store for the given phase.
+func ParseAndStorePhaseOutput(store *Store, taskID string, phase string, output string) error {
+	jsonStr, err := ParseHandoffSignal(output)
+	if err != nil {
+		return err
+	}
+
+	switch phase {
+	case "PLAN":
+		parsed, err := ParsePlanOutput(jsonStr)
+		if err != nil {
+			return err
+		}
+		store.SetPlanOutput(taskID, parsed)
+
+	case "IMPLEMENT":
+		parsed, err := ParseImplementOutput(jsonStr)
+		if err != nil {
+			return err
+		}
+		store.SetImplementOutput(taskID, parsed)
+
+	case "REVIEW":
+		parsed, err := ParseReviewOutput(jsonStr)
+		if err != nil {
+			return err
+		}
+		store.SetReviewOutput(taskID, parsed)
+
+	case "DOCS":
+		parsed, err := ParseDocsOutput(jsonStr)
+		if err != nil {
+			return err
+		}
+		store.SetDocsOutput(taskID, parsed)
+
+	case "PR_CREATION":
+		parsed, err := ParsePRCreationOutput(jsonStr)
+		if err != nil {
+			return err
+		}
+		store.SetPRCreationOutput(taskID, parsed)
+
+	default:
+		return fmt.Errorf("unknown phase: %s", phase)
+	}
+
+	return nil
+}
+
+// HasHandoffSignal returns true if the output contains an AGENTIUM_HANDOFF signal.
+func HasHandoffSignal(output string) bool {
+	return strings.Contains(output, HandoffSignalPrefix)
+}
+
+// ExtractAllHandoffSignals finds all AGENTIUM_HANDOFF signals in the output.
+// Useful when an agent emits multiple signals (though typically there should be one per phase).
+func ExtractAllHandoffSignals(output string) []string {
+	var signals []string
+	remaining := output
+
+	for {
+		idx := strings.Index(remaining, HandoffSignalPrefix)
+		if idx == -1 {
+			break
+		}
+
+		signalStart := remaining[idx+len(HandoffSignalPrefix):]
+		signalStart = strings.TrimSpace(signalStart)
+
+		if strings.HasPrefix(signalStart, "{") {
+			jsonStr, err := extractJSONObject(signalStart)
+			if err == nil {
+				signals = append(signals, jsonStr)
+			}
+		}
+
+		// Move past this signal
+		remaining = remaining[idx+len(HandoffSignalPrefix):]
+	}
+
+	return signals
+}

--- a/internal/handoff/parser_test.go
+++ b/internal/handoff/parser_test.go
@@ -1,0 +1,270 @@
+package handoff
+
+import (
+	"testing"
+)
+
+func TestParseHandoffSignal(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "simple plan output",
+			input: `Some text before AGENTIUM_HANDOFF: {"summary": "test", "files_to_modify": []} more text`,
+			want:  `{"summary": "test", "files_to_modify": []}`,
+		},
+		{
+			name: "multiline JSON",
+			input: `AGENTIUM_HANDOFF: {
+  "summary": "test",
+  "files_to_modify": ["file1.go"]
+}
+some text after`,
+			want: `{
+  "summary": "test",
+  "files_to_modify": ["file1.go"]
+}`,
+		},
+		{
+			name:  "nested objects",
+			input: `AGENTIUM_HANDOFF: {"steps": [{"number": 1, "data": {"key": "value"}}]}`,
+			want:  `{"steps": [{"number": 1, "data": {"key": "value"}}]}`,
+		},
+		{
+			name:    "no signal",
+			input:   "Some text without handoff signal",
+			wantErr: true,
+		},
+		{
+			name:    "signal without JSON",
+			input:   "AGENTIUM_HANDOFF: not json",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseHandoffSignal(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseHandoffSignal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseHandoffSignal() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePlanOutput(t *testing.T) {
+	jsonStr := `{
+		"summary": "Add user authentication",
+		"files_to_modify": ["auth.go", "handler.go"],
+		"files_to_create": ["middleware.go"],
+		"implementation_steps": [
+			{"number": 1, "description": "Add middleware", "file": "middleware.go"},
+			{"number": 2, "description": "Update handler"}
+		],
+		"testing_approach": "Unit tests"
+	}`
+
+	output, err := ParsePlanOutput(jsonStr)
+	if err != nil {
+		t.Fatalf("ParsePlanOutput() error = %v", err)
+	}
+
+	if output.Summary != "Add user authentication" {
+		t.Errorf("Summary = %q, want %q", output.Summary, "Add user authentication")
+	}
+	if len(output.FilesToModify) != 2 {
+		t.Errorf("FilesToModify len = %d, want 2", len(output.FilesToModify))
+	}
+	if len(output.FilesToCreate) != 1 {
+		t.Errorf("FilesToCreate len = %d, want 1", len(output.FilesToCreate))
+	}
+	if len(output.ImplementationSteps) != 2 {
+		t.Errorf("ImplementationSteps len = %d, want 2", len(output.ImplementationSteps))
+	}
+	if output.ImplementationSteps[0].File != "middleware.go" {
+		t.Errorf("Step 1 file = %q, want %q", output.ImplementationSteps[0].File, "middleware.go")
+	}
+}
+
+func TestParseImplementOutput(t *testing.T) {
+	jsonStr := `{
+		"branch_name": "agentium/issue-42-add-auth",
+		"commits": [
+			{"sha": "abc1234", "message": "Add auth middleware"},
+			{"sha": "def5678", "message": "Fix tests"}
+		],
+		"files_changed": ["auth.go", "auth_test.go"],
+		"tests_passed": true,
+		"test_output": "ok  ./..."
+	}`
+
+	output, err := ParseImplementOutput(jsonStr)
+	if err != nil {
+		t.Fatalf("ParseImplementOutput() error = %v", err)
+	}
+
+	if output.BranchName != "agentium/issue-42-add-auth" {
+		t.Errorf("BranchName = %q, want %q", output.BranchName, "agentium/issue-42-add-auth")
+	}
+	if len(output.Commits) != 2 {
+		t.Errorf("Commits len = %d, want 2", len(output.Commits))
+	}
+	if !output.TestsPassed {
+		t.Error("TestsPassed = false, want true")
+	}
+}
+
+func TestParseReviewOutput(t *testing.T) {
+	jsonStr := `{
+		"issues_found": [
+			{"file": "auth.go", "line": 42, "description": "Missing error check", "severity": "error", "fixed": true}
+		],
+		"fixes_applied": ["Added error handling in auth.go:42"],
+		"regression_needed": false,
+		"regression_reason": ""
+	}`
+
+	output, err := ParseReviewOutput(jsonStr)
+	if err != nil {
+		t.Fatalf("ParseReviewOutput() error = %v", err)
+	}
+
+	if len(output.IssuesFound) != 1 {
+		t.Errorf("IssuesFound len = %d, want 1", len(output.IssuesFound))
+	}
+	if output.IssuesFound[0].File != "auth.go" {
+		t.Errorf("Issue file = %q, want %q", output.IssuesFound[0].File, "auth.go")
+	}
+	if !output.IssuesFound[0].Fixed {
+		t.Error("Issue fixed = false, want true")
+	}
+	if output.RegressionNeeded {
+		t.Error("RegressionNeeded = true, want false")
+	}
+}
+
+func TestHasHandoffSignal(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"AGENTIUM_HANDOFF: {}", true},
+		{"Some AGENTIUM_HANDOFF: {} text", true},
+		{"No signal here", false},
+		{"AGENTIUM_STATUS: COMPLETE", false},
+	}
+
+	for _, tt := range tests {
+		got := HasHandoffSignal(tt.input)
+		if got != tt.want {
+			t.Errorf("HasHandoffSignal(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestExtractAllHandoffSignals(t *testing.T) {
+	input := `First signal: AGENTIUM_HANDOFF: {"a": 1}
+Some text
+Second signal: AGENTIUM_HANDOFF: {"b": 2}
+End`
+
+	signals := ExtractAllHandoffSignals(input)
+	if len(signals) != 2 {
+		t.Fatalf("ExtractAllHandoffSignals() = %d signals, want 2", len(signals))
+	}
+	if signals[0] != `{"a": 1}` {
+		t.Errorf("Signal 0 = %q, want %q", signals[0], `{"a": 1}`)
+	}
+	if signals[1] != `{"b": 2}` {
+		t.Errorf("Signal 1 = %q, want %q", signals[1], `{"b": 2}`)
+	}
+}
+
+func TestParseAndStorePhaseOutput(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	// Test PLAN phase
+	planOutput := `Some agent output
+AGENTIUM_HANDOFF: {"summary": "Test plan", "files_to_modify": [], "files_to_create": [], "implementation_steps": [], "testing_approach": "unit tests"}
+AGENTIUM_STATUS: COMPLETE`
+
+	err := ParseAndStorePhaseOutput(store, taskID, "PLAN", planOutput)
+	if err != nil {
+		t.Fatalf("ParseAndStorePhaseOutput(PLAN) error = %v", err)
+	}
+
+	plan := store.GetPlanOutput(taskID)
+	if plan == nil {
+		t.Fatal("expected plan output to be stored")
+	}
+	if plan.Summary != "Test plan" {
+		t.Errorf("Plan summary = %q, want %q", plan.Summary, "Test plan")
+	}
+}
+
+func TestExtractJSONObject(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "simple object",
+			input: `{"key": "value"}`,
+			want:  `{"key": "value"}`,
+		},
+		{
+			name:  "nested object",
+			input: `{"outer": {"inner": "value"}}`,
+			want:  `{"outer": {"inner": "value"}}`,
+		},
+		{
+			name:  "with array",
+			input: `{"arr": [1, 2, {"nested": true}]}`,
+			want:  `{"arr": [1, 2, {"nested": true}]}`,
+		},
+		{
+			name:  "with escaped quotes",
+			input: `{"str": "value with \"quotes\""}`,
+			want:  `{"str": "value with \"quotes\""}`,
+		},
+		{
+			name:  "with trailing text",
+			input: `{"key": "value"} more text`,
+			want:  `{"key": "value"}`,
+		},
+		{
+			name:    "not starting with brace",
+			input:   "not json",
+			wantErr: true,
+		},
+		{
+			name:    "incomplete object",
+			input:   `{"key": "value"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractJSONObject(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractJSONObject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("extractJSONObject() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/handoff/store.go
+++ b/internal/handoff/store.go
@@ -1,0 +1,278 @@
+package handoff
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Store manages structured phase outputs for a task.
+// Unlike the memory store which accumulates signals, the handoff store
+// maintains only the current state of each phase's output.
+type Store struct {
+	mu       sync.RWMutex
+	filePath string
+
+	// Per-task state, keyed by taskID (e.g., "issue:42")
+	tasks map[string]*TaskHandoff
+}
+
+// TaskHandoff holds all phase outputs for a single task.
+type TaskHandoff struct {
+	IssueContext *IssueContext     `json:"issue_context,omitempty"`
+	Plan         *PlanOutput       `json:"plan,omitempty"`
+	Implement    *ImplementOutput  `json:"implement,omitempty"`
+	Review       *ReviewOutput     `json:"review,omitempty"`
+	Docs         *DocsOutput       `json:"docs,omitempty"`
+	PRCreation   *PRCreationOutput `json:"pr_creation,omitempty"`
+}
+
+// StoreData is the on-disk representation of the handoff store.
+type StoreData struct {
+	Version string                   `json:"version"`
+	Tasks   map[string]*TaskHandoff  `json:"tasks"`
+}
+
+// NewStore creates a new handoff store for the given work directory.
+func NewStore(workDir string) *Store {
+	return &Store{
+		filePath: filepath.Join(workDir, ".agentium", "handoff.json"),
+		tasks:    make(map[string]*TaskHandoff),
+	}
+}
+
+// Load reads the handoff file from disk. If the file does not exist, the store
+// starts empty without error.
+func (s *Store) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raw, err := os.ReadFile(s.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var data StoreData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		// Invalid JSON - start fresh
+		return nil
+	}
+
+	if data.Tasks != nil {
+		s.tasks = data.Tasks
+	}
+	return nil
+}
+
+// Save writes the current handoff data to disk, creating the directory if needed.
+func (s *Store) Save() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dir := filepath.Dir(s.filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data := StoreData{
+		Version: "1",
+		Tasks:   s.tasks,
+	}
+
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.filePath, raw, 0644)
+}
+
+// getOrCreateTask returns the TaskHandoff for the given taskID, creating it if needed.
+func (s *Store) getOrCreateTask(taskID string) *TaskHandoff {
+	if s.tasks[taskID] == nil {
+		s.tasks[taskID] = &TaskHandoff{}
+	}
+	return s.tasks[taskID]
+}
+
+// SetIssueContext stores the issue context for a task.
+func (s *Store) SetIssueContext(taskID string, ctx *IssueContext) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getOrCreateTask(taskID).IssueContext = ctx
+}
+
+// GetIssueContext retrieves the issue context for a task.
+func (s *Store) GetIssueContext(taskID string) *IssueContext {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if task := s.tasks[taskID]; task != nil {
+		return task.IssueContext
+	}
+	return nil
+}
+
+// SetPlanOutput stores the PLAN phase output for a task.
+func (s *Store) SetPlanOutput(taskID string, output *PlanOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getOrCreateTask(taskID).Plan = output
+}
+
+// GetPlanOutput retrieves the PLAN phase output for a task.
+func (s *Store) GetPlanOutput(taskID string) *PlanOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if task := s.tasks[taskID]; task != nil {
+		return task.Plan
+	}
+	return nil
+}
+
+// SetImplementOutput stores the IMPLEMENT phase output for a task.
+func (s *Store) SetImplementOutput(taskID string, output *ImplementOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getOrCreateTask(taskID).Implement = output
+}
+
+// GetImplementOutput retrieves the IMPLEMENT phase output for a task.
+func (s *Store) GetImplementOutput(taskID string) *ImplementOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if task := s.tasks[taskID]; task != nil {
+		return task.Implement
+	}
+	return nil
+}
+
+// SetReviewOutput stores the REVIEW phase output for a task.
+func (s *Store) SetReviewOutput(taskID string, output *ReviewOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getOrCreateTask(taskID).Review = output
+}
+
+// GetReviewOutput retrieves the REVIEW phase output for a task.
+func (s *Store) GetReviewOutput(taskID string) *ReviewOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if task := s.tasks[taskID]; task != nil {
+		return task.Review
+	}
+	return nil
+}
+
+// SetDocsOutput stores the DOCS phase output for a task.
+func (s *Store) SetDocsOutput(taskID string, output *DocsOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getOrCreateTask(taskID).Docs = output
+}
+
+// GetDocsOutput retrieves the DOCS phase output for a task.
+func (s *Store) GetDocsOutput(taskID string) *DocsOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if task := s.tasks[taskID]; task != nil {
+		return task.Docs
+	}
+	return nil
+}
+
+// SetPRCreationOutput stores the PR_CREATION phase output for a task.
+func (s *Store) SetPRCreationOutput(taskID string, output *PRCreationOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getOrCreateTask(taskID).PRCreation = output
+}
+
+// GetPRCreationOutput retrieves the PR_CREATION phase output for a task.
+func (s *Store) GetPRCreationOutput(taskID string) *PRCreationOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if task := s.tasks[taskID]; task != nil {
+		return task.PRCreation
+	}
+	return nil
+}
+
+// ClearFromPhase clears all phase outputs from the specified phase onwards.
+// Used when regression is needed (e.g., REVIEW finds fundamental issues requiring re-planning).
+func (s *Store) ClearFromPhase(taskID string, phase string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	task := s.tasks[taskID]
+	if task == nil {
+		return
+	}
+
+	// Clear phases in order from the specified phase onwards
+	switch phase {
+	case "PLAN":
+		task.Plan = nil
+		fallthrough
+	case "IMPLEMENT":
+		task.Implement = nil
+		fallthrough
+	case "REVIEW":
+		task.Review = nil
+		fallthrough
+	case "DOCS":
+		task.Docs = nil
+		fallthrough
+	case "PR_CREATION":
+		task.PRCreation = nil
+	}
+}
+
+// HasPlanOutput returns true if the task has a PLAN output stored.
+func (s *Store) HasPlanOutput(taskID string) bool {
+	return s.GetPlanOutput(taskID) != nil
+}
+
+// HasImplementOutput returns true if the task has an IMPLEMENT output stored.
+func (s *Store) HasImplementOutput(taskID string) bool {
+	return s.GetImplementOutput(taskID) != nil
+}
+
+// Summary returns a human-readable summary of what's stored for a task.
+func (s *Store) Summary(taskID string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	task := s.tasks[taskID]
+	if task == nil {
+		return fmt.Sprintf("Task %s: no handoff data", taskID)
+	}
+
+	phases := []string{}
+	if task.IssueContext != nil {
+		phases = append(phases, "IssueContext")
+	}
+	if task.Plan != nil {
+		phases = append(phases, "Plan")
+	}
+	if task.Implement != nil {
+		phases = append(phases, "Implement")
+	}
+	if task.Review != nil {
+		phases = append(phases, "Review")
+	}
+	if task.Docs != nil {
+		phases = append(phases, "Docs")
+	}
+	if task.PRCreation != nil {
+		phases = append(phases, "PRCreation")
+	}
+
+	if len(phases) == 0 {
+		return fmt.Sprintf("Task %s: empty", taskID)
+	}
+	return fmt.Sprintf("Task %s: %v", taskID, phases)
+}

--- a/internal/handoff/store_test.go
+++ b/internal/handoff/store_test.go
@@ -1,0 +1,193 @@
+package handoff
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStore_SetGetIssueContext(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	taskID := "issue:42"
+	ctx := &IssueContext{
+		Number:     "42",
+		Title:      "Test Issue",
+		Body:       "Test body",
+		Repository: "owner/repo",
+	}
+
+	store.SetIssueContext(taskID, ctx)
+	got := store.GetIssueContext(taskID)
+
+	if got == nil {
+		t.Fatal("expected issue context, got nil")
+	}
+	if got.Number != "42" {
+		t.Errorf("expected number 42, got %s", got.Number)
+	}
+	if got.Title != "Test Issue" {
+		t.Errorf("expected title 'Test Issue', got %s", got.Title)
+	}
+}
+
+func TestStore_SetGetPlanOutput(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	taskID := "issue:42"
+	plan := &PlanOutput{
+		Summary:       "Test plan",
+		FilesToModify: []string{"file1.go", "file2.go"},
+		FilesToCreate: []string{"file3.go"},
+		ImplementationSteps: []ImplementationStep{
+			{Number: 1, Description: "Step 1", File: "file1.go"},
+			{Number: 2, Description: "Step 2"},
+		},
+		TestingApproach: "Unit tests",
+	}
+
+	store.SetPlanOutput(taskID, plan)
+	got := store.GetPlanOutput(taskID)
+
+	if got == nil {
+		t.Fatal("expected plan output, got nil")
+	}
+	if got.Summary != "Test plan" {
+		t.Errorf("expected summary 'Test plan', got %s", got.Summary)
+	}
+	if len(got.FilesToModify) != 2 {
+		t.Errorf("expected 2 files to modify, got %d", len(got.FilesToModify))
+	}
+	if len(got.ImplementationSteps) != 2 {
+		t.Errorf("expected 2 steps, got %d", len(got.ImplementationSteps))
+	}
+}
+
+func TestStore_ClearFromPhase(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	taskID := "issue:42"
+
+	// Set up all phases
+	store.SetIssueContext(taskID, &IssueContext{Number: "42"})
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "plan"})
+	store.SetImplementOutput(taskID, &ImplementOutput{BranchName: "branch"})
+	store.SetReviewOutput(taskID, &ReviewOutput{IssuesFound: []ReviewIssue{}})
+	store.SetDocsOutput(taskID, &DocsOutput{DocsUpdated: []string{}})
+	store.SetPRCreationOutput(taskID, &PRCreationOutput{PRNumber: 123})
+
+	// Clear from IMPLEMENT onwards
+	store.ClearFromPhase(taskID, "IMPLEMENT")
+
+	// Issue context and plan should still exist
+	if store.GetIssueContext(taskID) == nil {
+		t.Error("expected issue context to remain")
+	}
+	if store.GetPlanOutput(taskID) == nil {
+		t.Error("expected plan output to remain")
+	}
+
+	// Everything from IMPLEMENT onwards should be cleared
+	if store.GetImplementOutput(taskID) != nil {
+		t.Error("expected implement output to be cleared")
+	}
+	if store.GetReviewOutput(taskID) != nil {
+		t.Error("expected review output to be cleared")
+	}
+	if store.GetDocsOutput(taskID) != nil {
+		t.Error("expected docs output to be cleared")
+	}
+	if store.GetPRCreationOutput(taskID) != nil {
+		t.Error("expected PR creation output to be cleared")
+	}
+}
+
+func TestStore_SaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	taskID := "issue:42"
+	store.SetIssueContext(taskID, &IssueContext{
+		Number: "42",
+		Title:  "Test Issue",
+	})
+	store.SetPlanOutput(taskID, &PlanOutput{
+		Summary: "Test plan",
+	})
+
+	// Save
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	// Verify file exists
+	filePath := filepath.Join(dir, ".agentium", "handoff.json")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Fatal("handoff.json file not created")
+	}
+
+	// Load into new store
+	store2 := NewStore(dir)
+	if err := store2.Load(); err != nil {
+		t.Fatalf("failed to load: %v", err)
+	}
+
+	// Verify data
+	ctx := store2.GetIssueContext(taskID)
+	if ctx == nil {
+		t.Fatal("expected issue context after load")
+	}
+	if ctx.Number != "42" {
+		t.Errorf("expected number 42, got %s", ctx.Number)
+	}
+
+	plan := store2.GetPlanOutput(taskID)
+	if plan == nil {
+		t.Fatal("expected plan output after load")
+	}
+	if plan.Summary != "Test plan" {
+		t.Errorf("expected summary 'Test plan', got %s", plan.Summary)
+	}
+}
+
+func TestStore_HasPlanOutput(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	taskID := "issue:42"
+
+	if store.HasPlanOutput(taskID) {
+		t.Error("expected HasPlanOutput to return false initially")
+	}
+
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "test"})
+
+	if !store.HasPlanOutput(taskID) {
+		t.Error("expected HasPlanOutput to return true after setting")
+	}
+}
+
+func TestStore_Summary(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	taskID := "issue:42"
+
+	// Empty task
+	summary := store.Summary(taskID)
+	if summary != "Task issue:42: no handoff data" {
+		t.Errorf("unexpected summary: %s", summary)
+	}
+
+	// With some data
+	store.SetIssueContext(taskID, &IssueContext{Number: "42"})
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "test"})
+
+	summary = store.Summary(taskID)
+	if summary != "Task issue:42: [IssueContext Plan]" {
+		t.Errorf("unexpected summary: %s", summary)
+	}
+}

--- a/internal/handoff/types.go
+++ b/internal/handoff/types.go
@@ -1,0 +1,116 @@
+// Package handoff provides structured phase input/output contracts for the
+// sub-agents model. Each phase receives curated inputs and produces structured
+// outputs that the orchestrator routes forward to the next phase.
+package handoff
+
+// IssueContext provides the minimal context about an issue being worked on.
+// This is passed as input to the PLAN phase.
+type IssueContext struct {
+	Number     string `json:"number"`
+	Title      string `json:"title"`
+	Body       string `json:"body"`
+	Repository string `json:"repository"`
+}
+
+// ImplementationStep describes a single step in an implementation plan.
+type ImplementationStep struct {
+	Number      int    `json:"number"`
+	Description string `json:"description"`
+	File        string `json:"file,omitempty"` // Primary file affected (optional)
+}
+
+// PlanOutput is the structured output from the PLAN phase.
+type PlanOutput struct {
+	Summary             string               `json:"summary"`
+	FilesToModify       []string             `json:"files_to_modify"`
+	FilesToCreate       []string             `json:"files_to_create"`
+	ImplementationSteps []ImplementationStep `json:"implementation_steps"`
+	TestingApproach     string               `json:"testing_approach"`
+}
+
+// ExistingWorkContext describes prior work detected for an issue (branch/PR).
+type ExistingWorkContext struct {
+	Branch   string `json:"branch,omitempty"`
+	PRNumber string `json:"pr_number,omitempty"`
+	PRTitle  string `json:"pr_title,omitempty"`
+}
+
+// ImplementInput is the input for the IMPLEMENT phase.
+type ImplementInput struct {
+	IssueContext IssueContext         `json:"issue_context"`
+	Plan         PlanOutput           `json:"plan"`
+	ExistingWork *ExistingWorkContext `json:"existing_work,omitempty"`
+}
+
+// CommitInfo describes a git commit made during implementation.
+type CommitInfo struct {
+	SHA     string `json:"sha"`
+	Message string `json:"message"`
+}
+
+// ImplementOutput is the structured output from the IMPLEMENT phase.
+type ImplementOutput struct {
+	BranchName   string       `json:"branch_name"`
+	Commits      []CommitInfo `json:"commits"`
+	FilesChanged []string     `json:"files_changed"`
+	TestsPassed  bool         `json:"tests_passed"`
+	TestOutput   string       `json:"test_output,omitempty"`
+}
+
+// ReviewInput is the input for the REVIEW phase.
+type ReviewInput struct {
+	IssueContext   IssueContext    `json:"issue_context"`
+	PlanSummary    string          `json:"plan_summary"`
+	Implementation ImplementOutput `json:"implementation"`
+}
+
+// ReviewIssue describes an issue found during code review.
+type ReviewIssue struct {
+	File        string `json:"file"`
+	Line        int    `json:"line,omitempty"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"` // "error", "warning", "suggestion"
+	Fixed       bool   `json:"fixed"`
+}
+
+// ReviewOutput is the structured output from the REVIEW phase.
+type ReviewOutput struct {
+	IssuesFound      []ReviewIssue `json:"issues_found"`
+	FixesApplied     []string      `json:"fixes_applied"`
+	RegressionNeeded bool          `json:"regression_needed"`
+	RegressionReason string        `json:"regression_reason,omitempty"`
+}
+
+// DocsInput is the input for the DOCS phase.
+type DocsInput struct {
+	IssueContext IssueContext `json:"issue_context"`
+	PlanSummary  string       `json:"plan_summary"`
+	FilesChanged []string     `json:"files_changed"`
+}
+
+// DocsOutput is the structured output from the DOCS phase.
+type DocsOutput struct {
+	DocsUpdated   []string `json:"docs_updated"`
+	ReadmeChanged bool     `json:"readme_changed"`
+}
+
+// PRCreationInput is the input for the PR_CREATION phase.
+type PRCreationInput struct {
+	IssueContext IssueContext `json:"issue_context"`
+	BranchName   string       `json:"branch_name"`
+	PlanSummary  string       `json:"plan_summary"`
+	FilesChanged []string     `json:"files_changed"`
+	TestsPassed  bool         `json:"tests_passed"`
+	TestOutput   string       `json:"test_output,omitempty"`
+}
+
+// PRCreationOutput is the structured output from the PR_CREATION phase.
+type PRCreationOutput struct {
+	PRNumber int    `json:"pr_number"`
+	PRURL    string `json:"pr_url"`
+}
+
+// Config holds handoff feature configuration.
+type Config struct {
+	Enabled bool `json:"enabled"`
+}

--- a/internal/handoff/validator.go
+++ b/internal/handoff/validator.go
@@ -1,0 +1,310 @@
+package handoff
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidationError represents a validation failure with details.
+type ValidationError struct {
+	Phase   string
+	Field   string
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s validation error: %s - %s", e.Phase, e.Field, e.Message)
+}
+
+// ValidationResult contains the result of validating a phase output.
+type ValidationResult struct {
+	Valid    bool
+	Errors   []ValidationError
+	Warnings []string
+}
+
+// ValidatePlanOutput validates a PlanOutput has required fields.
+func ValidatePlanOutput(output *PlanOutput) ValidationResult {
+	result := ValidationResult{Valid: true}
+
+	if output == nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "PLAN",
+			Field:   "output",
+			Message: "output is nil",
+		})
+		return result
+	}
+
+	if strings.TrimSpace(output.Summary) == "" {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "PLAN",
+			Field:   "summary",
+			Message: "summary is required",
+		})
+	}
+
+	// At least one file should be modified or created
+	if len(output.FilesToModify) == 0 && len(output.FilesToCreate) == 0 {
+		result.Warnings = append(result.Warnings,
+			"no files to modify or create specified (might indicate no code changes needed)")
+	}
+
+	// Implementation steps are strongly recommended
+	if len(output.ImplementationSteps) == 0 {
+		result.Warnings = append(result.Warnings,
+			"no implementation steps specified")
+	}
+
+	return result
+}
+
+// ValidateImplementOutput validates an ImplementOutput has required fields.
+func ValidateImplementOutput(output *ImplementOutput) ValidationResult {
+	result := ValidationResult{Valid: true}
+
+	if output == nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "IMPLEMENT",
+			Field:   "output",
+			Message: "output is nil",
+		})
+		return result
+	}
+
+	if strings.TrimSpace(output.BranchName) == "" {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "IMPLEMENT",
+			Field:   "branch_name",
+			Message: "branch name is required",
+		})
+	}
+
+	// Commits should exist unless this is a continuation
+	if len(output.Commits) == 0 {
+		result.Warnings = append(result.Warnings,
+			"no commits recorded (might indicate continuation of existing work)")
+	}
+
+	// Files changed should typically exist
+	if len(output.FilesChanged) == 0 {
+		result.Warnings = append(result.Warnings,
+			"no files changed recorded")
+	}
+
+	// Tests passing is important but not blocking
+	if !output.TestsPassed {
+		result.Warnings = append(result.Warnings,
+			"tests did not pass - review phase should address this")
+	}
+
+	return result
+}
+
+// ValidateReviewOutput validates a ReviewOutput has required fields.
+func ValidateReviewOutput(output *ReviewOutput) ValidationResult {
+	result := ValidationResult{Valid: true}
+
+	if output == nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "REVIEW",
+			Field:   "output",
+			Message: "output is nil",
+		})
+		return result
+	}
+
+	// If regression is needed, reason should be provided
+	if output.RegressionNeeded && strings.TrimSpace(output.RegressionReason) == "" {
+		result.Warnings = append(result.Warnings,
+			"regression requested but no reason provided")
+	}
+
+	// Check that issues marked as fixed have corresponding fixes applied
+	fixedCount := 0
+	for _, issue := range output.IssuesFound {
+		if issue.Fixed {
+			fixedCount++
+		}
+	}
+	if fixedCount > 0 && len(output.FixesApplied) == 0 {
+		result.Warnings = append(result.Warnings,
+			"issues marked as fixed but no fixes recorded in fixes_applied")
+	}
+
+	return result
+}
+
+// ValidateDocsOutput validates a DocsOutput.
+func ValidateDocsOutput(output *DocsOutput) ValidationResult {
+	result := ValidationResult{Valid: true}
+
+	if output == nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "DOCS",
+			Field:   "output",
+			Message: "output is nil",
+		})
+		return result
+	}
+
+	// Docs output can be empty (no docs needed), which is valid
+	return result
+}
+
+// ValidatePRCreationOutput validates a PRCreationOutput has required fields.
+func ValidatePRCreationOutput(output *PRCreationOutput) ValidationResult {
+	result := ValidationResult{Valid: true}
+
+	if output == nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "PR_CREATION",
+			Field:   "output",
+			Message: "output is nil",
+		})
+		return result
+	}
+
+	if output.PRNumber <= 0 {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Phase:   "PR_CREATION",
+			Field:   "pr_number",
+			Message: "valid PR number is required",
+		})
+	}
+
+	if strings.TrimSpace(output.PRURL) == "" {
+		result.Warnings = append(result.Warnings,
+			"PR URL not provided")
+	}
+
+	return result
+}
+
+// ValidatePhaseOutput validates the output for a given phase.
+func ValidatePhaseOutput(phase string, output interface{}) ValidationResult {
+	switch phase {
+	case "PLAN":
+		if o, ok := output.(*PlanOutput); ok {
+			return ValidatePlanOutput(o)
+		}
+		return ValidationResult{
+			Valid:  false,
+			Errors: []ValidationError{{Phase: "PLAN", Field: "type", Message: "expected *PlanOutput"}},
+		}
+
+	case "IMPLEMENT":
+		if o, ok := output.(*ImplementOutput); ok {
+			return ValidateImplementOutput(o)
+		}
+		return ValidationResult{
+			Valid:  false,
+			Errors: []ValidationError{{Phase: "IMPLEMENT", Field: "type", Message: "expected *ImplementOutput"}},
+		}
+
+	case "REVIEW":
+		if o, ok := output.(*ReviewOutput); ok {
+			return ValidateReviewOutput(o)
+		}
+		return ValidationResult{
+			Valid:  false,
+			Errors: []ValidationError{{Phase: "REVIEW", Field: "type", Message: "expected *ReviewOutput"}},
+		}
+
+	case "DOCS":
+		if o, ok := output.(*DocsOutput); ok {
+			return ValidateDocsOutput(o)
+		}
+		return ValidationResult{
+			Valid:  false,
+			Errors: []ValidationError{{Phase: "DOCS", Field: "type", Message: "expected *DocsOutput"}},
+		}
+
+	case "PR_CREATION":
+		if o, ok := output.(*PRCreationOutput); ok {
+			return ValidatePRCreationOutput(o)
+		}
+		return ValidationResult{
+			Valid:  false,
+			Errors: []ValidationError{{Phase: "PR_CREATION", Field: "type", Message: "expected *PRCreationOutput"}},
+		}
+
+	default:
+		return ValidationResult{
+			Valid:  false,
+			Errors: []ValidationError{{Phase: phase, Field: "phase", Message: "unknown phase"}},
+		}
+	}
+}
+
+// CanAdvanceToPhase checks if the handoff store has sufficient data to start the given phase.
+func CanAdvanceToPhase(store *Store, taskID string, phase string) (bool, string) {
+	switch phase {
+	case "PLAN":
+		// PLAN only needs issue context
+		if store.GetIssueContext(taskID) == nil {
+			return false, "issue context required for PLAN phase"
+		}
+		return true, ""
+
+	case "IMPLEMENT":
+		// IMPLEMENT needs issue context and plan
+		if store.GetIssueContext(taskID) == nil {
+			return false, "issue context required for IMPLEMENT phase"
+		}
+		if store.GetPlanOutput(taskID) == nil {
+			return false, "plan output required for IMPLEMENT phase"
+		}
+		return true, ""
+
+	case "REVIEW":
+		// REVIEW needs issue context, plan, and implementation
+		if store.GetIssueContext(taskID) == nil {
+			return false, "issue context required for REVIEW phase"
+		}
+		if store.GetPlanOutput(taskID) == nil {
+			return false, "plan output required for REVIEW phase"
+		}
+		if store.GetImplementOutput(taskID) == nil {
+			return false, "implement output required for REVIEW phase"
+		}
+		return true, ""
+
+	case "DOCS":
+		// DOCS needs issue context, plan, and implementation
+		if store.GetIssueContext(taskID) == nil {
+			return false, "issue context required for DOCS phase"
+		}
+		if store.GetPlanOutput(taskID) == nil {
+			return false, "plan output required for DOCS phase"
+		}
+		if store.GetImplementOutput(taskID) == nil {
+			return false, "implement output required for DOCS phase"
+		}
+		return true, ""
+
+	case "PR_CREATION":
+		// PR_CREATION needs issue context, plan, and implementation
+		if store.GetIssueContext(taskID) == nil {
+			return false, "issue context required for PR_CREATION phase"
+		}
+		if store.GetPlanOutput(taskID) == nil {
+			return false, "plan output required for PR_CREATION phase"
+		}
+		if store.GetImplementOutput(taskID) == nil {
+			return false, "implement output required for PR_CREATION phase"
+		}
+		return true, ""
+
+	default:
+		return false, fmt.Sprintf("unknown phase: %s", phase)
+	}
+}

--- a/internal/handoff/validator_test.go
+++ b/internal/handoff/validator_test.go
@@ -1,0 +1,249 @@
+package handoff
+
+import (
+	"testing"
+)
+
+func TestValidatePlanOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     *PlanOutput
+		wantValid  bool
+		wantErrors int
+	}{
+		{
+			name:       "nil output",
+			output:     nil,
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name:       "empty summary",
+			output:     &PlanOutput{Summary: ""},
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name: "valid output",
+			output: &PlanOutput{
+				Summary:       "Test plan",
+				FilesToModify: []string{"file.go"},
+				ImplementationSteps: []ImplementationStep{
+					{Number: 1, Description: "Step 1"},
+				},
+			},
+			wantValid:  true,
+			wantErrors: 0,
+		},
+		{
+			name: "no files - warning only",
+			output: &PlanOutput{
+				Summary: "Test plan",
+			},
+			wantValid:  true, // Warning, not error
+			wantErrors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidatePlanOutput(tt.output)
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if len(result.Errors) != tt.wantErrors {
+				t.Errorf("Errors = %d, want %d", len(result.Errors), tt.wantErrors)
+			}
+		})
+	}
+}
+
+func TestValidateImplementOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     *ImplementOutput
+		wantValid  bool
+		wantErrors int
+	}{
+		{
+			name:       "nil output",
+			output:     nil,
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name:       "empty branch name",
+			output:     &ImplementOutput{BranchName: ""},
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name: "valid output",
+			output: &ImplementOutput{
+				BranchName:   "agentium/issue-42",
+				Commits:      []CommitInfo{{SHA: "abc", Message: "test"}},
+				FilesChanged: []string{"file.go"},
+				TestsPassed:  true,
+			},
+			wantValid:  true,
+			wantErrors: 0,
+		},
+		{
+			name: "tests failed - warning only",
+			output: &ImplementOutput{
+				BranchName:  "agentium/issue-42",
+				TestsPassed: false,
+			},
+			wantValid:  true, // Warning, not error
+			wantErrors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateImplementOutput(tt.output)
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if len(result.Errors) != tt.wantErrors {
+				t.Errorf("Errors = %d, want %d", len(result.Errors), tt.wantErrors)
+			}
+		})
+	}
+}
+
+func TestValidatePRCreationOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     *PRCreationOutput
+		wantValid  bool
+		wantErrors int
+	}{
+		{
+			name:       "nil output",
+			output:     nil,
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name:       "zero PR number",
+			output:     &PRCreationOutput{PRNumber: 0},
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name: "valid output",
+			output: &PRCreationOutput{
+				PRNumber: 123,
+				PRURL:    "https://github.com/owner/repo/pull/123",
+			},
+			wantValid:  true,
+			wantErrors: 0,
+		},
+		{
+			name: "missing URL - warning only",
+			output: &PRCreationOutput{
+				PRNumber: 123,
+			},
+			wantValid:  true, // Warning, not error
+			wantErrors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidatePRCreationOutput(tt.output)
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if len(result.Errors) != tt.wantErrors {
+				t.Errorf("Errors = %d, want %d", len(result.Errors), tt.wantErrors)
+			}
+		})
+	}
+}
+
+func TestCanAdvanceToPhase(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	taskID := "issue:42"
+
+	// PLAN only needs issue context
+	store.SetIssueContext(taskID, &IssueContext{Number: "42"})
+
+	canAdvance, reason := CanAdvanceToPhase(store, taskID, "PLAN")
+	if !canAdvance {
+		t.Errorf("should be able to advance to PLAN: %s", reason)
+	}
+
+	// IMPLEMENT needs plan
+	canAdvance, reason = CanAdvanceToPhase(store, taskID, "IMPLEMENT")
+	if canAdvance {
+		t.Error("should not be able to advance to IMPLEMENT without plan")
+	}
+
+	store.SetPlanOutput(taskID, &PlanOutput{Summary: "test"})
+
+	canAdvance, reason = CanAdvanceToPhase(store, taskID, "IMPLEMENT")
+	if !canAdvance {
+		t.Errorf("should be able to advance to IMPLEMENT: %s", reason)
+	}
+
+	// REVIEW needs implementation
+	canAdvance, reason = CanAdvanceToPhase(store, taskID, "REVIEW")
+	if canAdvance {
+		t.Error("should not be able to advance to REVIEW without implementation")
+	}
+
+	store.SetImplementOutput(taskID, &ImplementOutput{BranchName: "test"})
+
+	canAdvance, reason = CanAdvanceToPhase(store, taskID, "REVIEW")
+	if !canAdvance {
+		t.Errorf("should be able to advance to REVIEW: %s", reason)
+	}
+}
+
+func TestValidateReviewOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     *ReviewOutput
+		wantValid  bool
+		wantErrors int
+	}{
+		{
+			name:       "nil output",
+			output:     nil,
+			wantValid:  false,
+			wantErrors: 1,
+		},
+		{
+			name: "valid empty output",
+			output: &ReviewOutput{
+				IssuesFound: []ReviewIssue{},
+			},
+			wantValid:  true,
+			wantErrors: 0,
+		},
+		{
+			name: "regression without reason - warning",
+			output: &ReviewOutput{
+				RegressionNeeded: true,
+				RegressionReason: "",
+			},
+			wantValid:  true, // Warning, not error
+			wantErrors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateReviewOutput(tt.output)
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if len(result.Errors) != tt.wantErrors {
+				t.Errorf("Errors = %d, want %d", len(result.Errors), tt.wantErrors)
+			}
+		})
+	}
+}

--- a/prompts/skills/docs.md
+++ b/prompts/skills/docs.md
@@ -26,7 +26,16 @@ You are in the **DOCS** phase. Your job is to make MINIMAL documentation updates
 
 ### Completion
 
-When documentation is updated (or no updates needed), emit:
+When documentation is updated (or no updates needed), emit a structured handoff signal:
+
+```
+AGENTIUM_HANDOFF: {
+  "docs_updated": ["<list of documentation files updated, empty if none>"],
+  "readme_changed": false
+}
+```
+
+Then emit the completion status:
 ```
 AGENTIUM_STATUS: COMPLETE
 ```

--- a/prompts/skills/implement.md
+++ b/prompts/skills/implement.md
@@ -28,3 +28,35 @@ Use a short, descriptive suffix (e.g., `agentium/issue-42-add-login-button`)
 - Make focused, minimal changes that address the issue
 - Follow existing code style and patterns
 - Add tests for new functionality when appropriate
+
+### Step 6: Run Tests
+- Run the project's test suite to verify changes
+- Fix any failing tests before proceeding
+
+### Step 7: Commit Changes
+- Write clear, descriptive commit messages
+- Reference the issue number in commits
+
+### Completion
+
+When implementation is complete, emit a structured handoff signal:
+
+```
+AGENTIUM_HANDOFF: {
+  "branch_name": "<the branch you created or are working on>",
+  "commits": [{"sha": "<commit sha>", "message": "<commit message>"}],
+  "files_changed": ["<list of files you modified>"],
+  "tests_passed": true,
+  "test_output": "<brief test output summary>"
+}
+```
+
+Then emit the completion status:
+```
+AGENTIUM_STATUS: TESTS_PASSED
+```
+
+Or if tests failed:
+```
+AGENTIUM_STATUS: TESTS_FAILED <summary of failures>
+```

--- a/prompts/skills/plan.md
+++ b/prompts/skills/plan.md
@@ -38,8 +38,23 @@ Your plan should include:
 
 ### Completion
 
-When your plan is ready, emit:
+When your plan is ready, emit a structured handoff signal with your plan:
+
 ```
-AGENTIUM_MEMORY: DECISION <one-line summary of your approach>
+AGENTIUM_HANDOFF: {
+  "summary": "<one-sentence description of what needs to be done>",
+  "files_to_modify": ["<list of existing files to change>"],
+  "files_to_create": ["<list of new files if any>"],
+  "implementation_steps": [
+    {"number": 1, "description": "<step description>", "file": "<primary file if applicable>"}
+  ],
+  "testing_approach": "<how changes will be verified>"
+}
+```
+
+Then emit the completion status:
+```
 AGENTIUM_STATUS: COMPLETE
 ```
+
+Note: The AGENTIUM_HANDOFF JSON should be on a single line or a properly formatted JSON block.

--- a/prompts/skills/pr_creation.md
+++ b/prompts/skills/pr_creation.md
@@ -21,3 +21,19 @@ After creating the PR:
 - Review the PR diff one more time
 - If you find issues, push additional commits to fix them
 - Update the PR description if needed
+
+### Completion
+
+When the PR is created, emit a structured handoff signal:
+
+```
+AGENTIUM_HANDOFF: {
+  "pr_number": <the PR number>,
+  "pr_url": "<the full PR URL>"
+}
+```
+
+Then emit the completion status:
+```
+AGENTIUM_STATUS: PR_CREATED <PR URL>
+```

--- a/prompts/skills/review.md
+++ b/prompts/skills/review.md
@@ -27,7 +27,30 @@ You are in the **REVIEW** phase. Your job is to review the implementation that w
 
 ### Completion
 
-When the review is complete and all issues are fixed, emit:
+When the review is complete, emit a structured handoff signal:
+
+```
+AGENTIUM_HANDOFF: {
+  "issues_found": [
+    {"file": "<file path>", "line": <line number>, "description": "<issue>", "severity": "<error|warning|suggestion>", "fixed": <true|false>}
+  ],
+  "fixes_applied": ["<description of each fix made>"],
+  "regression_needed": false,
+  "regression_reason": ""
+}
+```
+
+If the implementation has fundamental issues requiring a return to planning:
+```
+AGENTIUM_HANDOFF: {
+  "issues_found": [...],
+  "fixes_applied": [],
+  "regression_needed": true,
+  "regression_reason": "<why re-planning is needed>"
+}
+```
+
+Then emit the completion status:
 ```
 AGENTIUM_STATUS: COMPLETE
 ```

--- a/prompts/skills/status_signals.md
+++ b/prompts/skills/status_signals.md
@@ -119,3 +119,55 @@ AGENTIUM_EVAL: ITERATE Tests failed in auth/handler_test.go - fix the nil pointe
 # Cannot proceed
 AGENTIUM_EVAL: BLOCKED Issue requirements are ambiguous - need clarification on auth method
 ```
+
+## HANDOFF SIGNALING
+
+Emit handoff signals to pass structured data between phases. This enables minimal context injection
+where each phase receives only the curated output from previous phases.
+
+Format: `AGENTIUM_HANDOFF: <json>`
+
+The JSON content varies by phase:
+
+### PLAN Phase Output
+```json
+AGENTIUM_HANDOFF: {
+  "summary": "One-sentence description",
+  "files_to_modify": ["path/to/file.go"],
+  "files_to_create": ["path/to/new.go"],
+  "implementation_steps": [
+    {"number": 1, "description": "Add handler", "file": "handler.go"}
+  ],
+  "testing_approach": "Unit tests for handler"
+}
+```
+
+### IMPLEMENT Phase Output
+```json
+AGENTIUM_HANDOFF: {
+  "branch_name": "agentium/issue-42-add-feature",
+  "commits": [{"sha": "abc1234", "message": "Add feature"}],
+  "files_changed": ["handler.go", "handler_test.go"],
+  "tests_passed": true,
+  "test_output": "ok  ./..."
+}
+```
+
+### REVIEW Phase Output
+```json
+AGENTIUM_HANDOFF: {
+  "issues_found": [
+    {"file": "handler.go", "line": 42, "description": "Missing error check", "severity": "error", "fixed": true}
+  ],
+  "fixes_applied": ["Added error handling in handler.go"],
+  "regression_needed": false,
+  "regression_reason": ""
+}
+```
+
+### Tips
+
+1. **Emit once per phase** - Only one AGENTIUM_HANDOFF signal should be emitted per phase completion
+2. **Keep JSON valid** - The controller parses this JSON; invalid JSON will be ignored
+3. **Be specific** - Include concrete file paths, commit SHAs, and test results
+4. **Still emit STATUS** - Handoff signals complement status signals, don't replace them


### PR DESCRIPTION
## Summary

- Implements the structured handoff system for sub-agents model
- Each phase receives curated inputs and produces structured outputs
- Replaces accumulated-context memory model when `handoff.enabled=true`
- True agent isolation - no inherited memory leakage between phases

## Changes

### New Package: `internal/handoff/`
- **types.go**: Phase input/output contract types (IssueContext, PlanOutput, ImplementOutput, ReviewOutput, DocsOutput, PRCreationOutput)
- **store.go**: Structured handoff storage (per-task state management)
- **builders.go**: Phase input builders (curated context for each phase)
- **parser.go**: AGENTIUM_HANDOFF signal parser
- **validator.go**: Handoff validation for phase outputs

### Modified Files
- **controller.go**: Add handoff store initialization and `isHandoffEnabled()` helper
- **phase_loop.go**: Process handoff outputs, handle regression with handoff clearing
- **delegation.go**: True isolation - use PhaseInput instead of MemoryContext when handoff enabled
- **interface.go**: Add `PhaseInput` and `HandoffOutput` fields

### Skill Prompts Updated
- Added AGENTIUM_HANDOFF signal documentation to status_signals.md
- Updated plan.md, implement.md, review.md, docs.md, pr_creation.md with handoff output format

## Migration Strategy

This implements Phase 1 (Parallel Systems):
- Handoff runs alongside existing memory system
- Feature flag: `handoff.enabled` in session config
- When enabled, handoff takes precedence; memory serves as fallback

## Test Plan

- [x] All existing tests pass
- [x] New handoff package tests pass (store, parser, builders, validator)
- [x] `go build ./...` compiles successfully
- [ ] Manual test with `handoff.enabled=true` in phase loop

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)