### PR TITLE
Gate docker command logging behind --verbose flag

### DIFF
--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -140,6 +140,7 @@ func runLocalSession(cmd *cobra.Command, args []string) error {
 		MaxDuration:   cfg.Session.MaxDuration,
 		Prompt:        cfg.Session.Prompt,
 		Interactive:   true, // Enable interactive mode
+		Verbose:       viper.GetBool("verbose"),
 	}
 
 	// Set Claude auth config

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -132,9 +132,10 @@ type SessionConfig struct {
 	Handoff struct {
 		Enabled bool `json:"enabled,omitempty"`
 	} `json:"handoff,omitempty"`
-	Routing *routing.PhaseRouting `json:"routing,omitempty"`
+	Routing    *routing.PhaseRouting `json:"routing,omitempty"`
 	Delegation *DelegationConfig     `json:"delegation,omitempty"`
 	PhaseLoop  *PhaseLoopConfig      `json:"phase_loop,omitempty"`
+	Verbose    bool                  `json:"verbose,omitempty"`
 }
 
 // DefaultConfigPath is the default path for the session config file

--- a/internal/controller/docker_interactive.go
+++ b/internal/controller/docker_interactive.go
@@ -75,7 +75,9 @@ func (c *Controller) runAgentContainerInteractive(ctx context.Context, params co
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	c.logger.Printf("Running interactive agent: docker %s", strings.Join(args, " "))
+	if c.config.Verbose {
+		c.logger.Printf("Running interactive agent: docker %s", strings.Join(args, " "))
+	}
 
 	// Run the container and wait for completion
 	err := cmd.Run()


### PR DESCRIPTION
## Summary
- Hide the full docker command line (which includes credential mount paths) from terminal output unless `--verbose` is enabled
- Added `Verbose` field to `SessionConfig` struct
- Pass verbose flag from CLI to controller in `run_local.go`
- Gate the docker command logging in `docker_interactive.go`

## Test plan
- [ ] Run `agentium run --local` and verify docker command is NOT logged
- [ ] Run `agentium run --local --verbose` and verify docker command IS logged
- [ ] Verify `go build ./...` compiles successfully
- [ ] Verify `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)