### PR TITLE
Move git clone inside Docker container for --local mode

### DIFF
--- a/docker/aider/Dockerfile
+++ b/docker/aider/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir -p /workspace && chown agentium:agentium /workspace
 # Copy runtime installation scripts
 COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh
 COPY docker/scripts/agent-wrapper.sh /runtime-scripts/agent-wrapper.sh
+COPY docker/scripts/setup-workspace.sh /runtime-scripts/setup-workspace.sh
 RUN chmod +x /runtime-scripts/*.sh
 
 # Configure git for the user

--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -40,6 +40,7 @@ RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
 # Copy runtime installation scripts
 COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh
 COPY docker/scripts/agent-wrapper.sh /runtime-scripts/agent-wrapper.sh
+COPY docker/scripts/setup-workspace.sh /runtime-scripts/setup-workspace.sh
 RUN chmod +x /runtime-scripts/*.sh
 
 # Set working directory

--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -40,6 +40,7 @@ RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
 # Copy runtime installation scripts
 COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh
 COPY docker/scripts/agent-wrapper.sh /runtime-scripts/agent-wrapper.sh
+COPY docker/scripts/setup-workspace.sh /runtime-scripts/setup-workspace.sh
 RUN chmod +x /runtime-scripts/*.sh
 
 # Set working directory

--- a/docker/scripts/agent-wrapper.sh
+++ b/docker/scripts/agent-wrapper.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-# Wrapper script that installs language runtime before executing the agent
+# Wrapper script that sets up workspace and installs language runtime before executing the agent
 
 set -e
+
+# Clone repository inside container if requested
+if [ "${AGENTIUM_CLONE_INSIDE:-}" = "true" ]; then
+    /runtime-scripts/setup-workspace.sh
+fi
 
 # Install runtime based on project type
 /runtime-scripts/install-runtime.sh

--- a/docker/scripts/setup-workspace.sh
+++ b/docker/scripts/setup-workspace.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Workspace setup script for cloning repository inside container
+# This runs before the agent when AGENTIUM_CLONE_INSIDE=true
+
+set -e
+
+# Function to log messages
+log() {
+    echo "[setup-workspace] $1" >&2
+}
+
+# Check if workspace already has content (repo already cloned)
+check_workspace() {
+    if [ -d "/workspace/.git" ]; then
+        log "Repository already exists in workspace, skipping clone"
+        return 0
+    fi
+    return 1
+}
+
+# Authenticate with GitHub using GITHUB_TOKEN if available
+auth_with_token() {
+    if [ -n "$GITHUB_TOKEN" ]; then
+        log "Authenticating with GitHub using GITHUB_TOKEN..."
+        echo "$GITHUB_TOKEN" | gh auth login --with-token
+        return $?
+    fi
+    return 1
+}
+
+# Check if gh is already authenticated
+check_gh_auth() {
+    if gh auth status >/dev/null 2>&1; then
+        log "GitHub CLI is already authenticated"
+        return 0
+    fi
+    return 1
+}
+
+# Interactive authentication via gh auth login
+auth_interactive() {
+    # Check if we have a TTY for interactive input
+    if [ -t 0 ]; then
+        log "No GITHUB_TOKEN found. Starting interactive GitHub authentication..."
+        log "Please follow the prompts to authenticate with GitHub."
+        echo
+        gh auth login
+        return $?
+    else
+        log "ERROR: No TTY available for interactive authentication"
+        log "Please set GITHUB_TOKEN environment variable or run with -it flag"
+        return 1
+    fi
+}
+
+# Clone the repository
+clone_repository() {
+    if [ -z "$AGENTIUM_REPOSITORY" ]; then
+        log "ERROR: AGENTIUM_REPOSITORY environment variable not set"
+        return 1
+    fi
+
+    log "Cloning repository: $AGENTIUM_REPOSITORY"
+
+    # Clone to a temp directory first, then move contents to /workspace
+    # This handles the case where /workspace already exists but is empty
+    TEMP_DIR=$(mktemp -d)
+
+    if gh repo clone "$AGENTIUM_REPOSITORY" "$TEMP_DIR" -- --depth 1; then
+        # Move all contents (including hidden files) to workspace
+        shopt -s dotglob
+        mv "$TEMP_DIR"/* /workspace/ 2>/dev/null || true
+        shopt -u dotglob
+        rm -rf "$TEMP_DIR"
+        log "Repository cloned successfully"
+        return 0
+    else
+        rm -rf "$TEMP_DIR"
+        log "ERROR: Failed to clone repository"
+        return 1
+    fi
+}
+
+# Main setup logic
+main() {
+    log "Setting up workspace..."
+
+    # Skip if workspace already has the repository
+    if check_workspace; then
+        return 0
+    fi
+
+    # Try to authenticate
+    if ! check_gh_auth; then
+        # Try token-based auth first, fall back to interactive
+        if ! auth_with_token; then
+            if ! auth_interactive; then
+                log "ERROR: GitHub authentication failed"
+                exit 1
+            fi
+        fi
+    fi
+
+    # Clone the repository
+    if ! clone_repository; then
+        exit 1
+    fi
+
+    log "Workspace setup complete"
+}
+
+# Run main function
+main

--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -32,10 +32,7 @@ func runLocalSession(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
-	// Verify GITHUB_TOKEN is set
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		return fmt.Errorf("GITHUB_TOKEN environment variable is required for --local mode\n\nSet it with:\n  export GITHUB_TOKEN=<your-github-token>")
-	}
+	// Note: GITHUB_TOKEN is optional - if not set, auth happens inside the container via gh auth login
 
 	// Load and validate configuration
 	cfg, err := config.Load()
@@ -131,16 +128,17 @@ func runLocalSession(cmd *cobra.Command, args []string) error {
 
 	// Build controller session config
 	sessionConfig := controller.SessionConfig{
-		ID:            sessionID,
-		Repository:    cfg.Session.Repository,
-		Tasks:         cfg.Session.Tasks,
-		PRs:           cfg.Session.PRs,
-		Agent:         cfg.Session.Agent,
-		MaxIterations: cfg.Session.MaxIterations,
-		MaxDuration:   cfg.Session.MaxDuration,
-		Prompt:        cfg.Session.Prompt,
-		Interactive:   true, // Enable interactive mode
-		Verbose:       viper.GetBool("verbose"),
+		ID:                   sessionID,
+		Repository:           cfg.Session.Repository,
+		Tasks:                cfg.Session.Tasks,
+		PRs:                  cfg.Session.PRs,
+		Agent:                cfg.Session.Agent,
+		MaxIterations:        cfg.Session.MaxIterations,
+		MaxDuration:          cfg.Session.MaxDuration,
+		Prompt:               cfg.Session.Prompt,
+		Interactive:          true, // Enable interactive mode
+		CloneInsideContainer: true, // Clone inside Docker container for reliable auth
+		Verbose:              viper.GetBool("verbose"),
 	}
 
 	// Set Claude auth config

--- a/internal/controller/docker_interactive.go
+++ b/internal/controller/docker_interactive.go
@@ -45,6 +45,12 @@ func (c *Controller) runAgentContainerInteractive(ctx context.Context, params co
 		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
 	}
 
+	// Pass clone-inside-container environment variables
+	if c.config.CloneInsideContainer {
+		args = append(args, "-e", "AGENTIUM_CLONE_INSIDE=true")
+		args = append(args, "-e", fmt.Sprintf("AGENTIUM_REPOSITORY=%s", c.config.Repository))
+	}
+
 	// Mount Claude OAuth credentials if configured
 	if c.config.ClaudeAuth.AuthMode == "oauth" {
 		authPath, err := c.writeInteractiveAuthFile("claude-auth.json", c.config.ClaudeAuth.AuthJSONBase64)


### PR DESCRIPTION
## Summary
- Moves repository cloning inside Docker container when using `--local` mode
- Makes GITHUB_TOKEN optional - authentication can happen interactively via `gh auth login` inside the container
- Adds `setup-workspace.sh` script that handles authentication and cloning inside the container

## Changes
- Add `CloneInsideContainer` field to `SessionConfig`
- Skip host-side clone when flag is set
- Create `setup-workspace.sh` script for in-container cloning
- Modify `agent-wrapper.sh` to call setup script conditionally
- Pass `AGENTIUM_CLONE_INSIDE` and `AGENTIUM_REPOSITORY` env vars to container
- Update all Dockerfiles to include `setup-workspace.sh`
- Make `GITHUB_TOKEN` optional for `--local` mode

## Test plan
- [ ] Build the Docker images:
  ```bash
  docker build -f docker/claudecode/Dockerfile -t agentium-claudecode:dev .
  ```
- [ ] Test with GITHUB_TOKEN:
  ```bash
  export GITHUB_TOKEN=$(gh auth token)
  ./agentium run --local --issues 197
  ```
  Expected: Clone succeeds automatically inside container
- [ ] Test without GITHUB_TOKEN (interactive):
  ```bash
  unset GITHUB_TOKEN
  ./agentium run --local --issues 197
  ```
  Expected: Prompts for `gh auth login` inside container
- [ ] Run tests: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)