### PR TITLE
Fix clone URL missing github.com domain

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -751,7 +751,8 @@ func (c *Controller) cloneRepository(ctx context.Context) error {
 	// Parse repository URL
 	repo := c.config.Repository
 	if !strings.HasPrefix(repo, "https://") && !strings.HasPrefix(repo, "git@") {
-		repo = "https://" + repo
+		// Handle owner/repo shorthand format (e.g., "andymwolf/agentium")
+		repo = "https://github.com/" + repo
 	}
 
 	// Clone with token authentication


### PR DESCRIPTION
## Summary
- Fixes repository clone URL construction when using owner/repo shorthand format
- Previously: `andymwolf/agentium` → `https://andymwolf/agentium` (broken)
- Now: `andymwolf/agentium` → `https://github.com/andymwolf/agentium` (correct)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy and verify cloud sessions clone successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)