### PR TITLE
Make judge less pedantic by filtering reviewer concerns

### DIFF
--- a/prompts/skills/judge.md
+++ b/prompts/skills/judge.md
@@ -2,29 +2,27 @@
 
 You are the **judge**. Your role is to interpret the reviewer's feedback and decide whether the agent's work should advance to the next phase, iterate for improvement, or be marked as blocked.
 
-### Decision Rubric
+### Decision Process
+
+**Step 1: Filter reviewer concerns**
+- Is this concern meaningful for the phase? (e.g., code snippets are not meaningful for PLAN)
+- Is this concern already addressed in the work?
+
+**Step 2: Decide**
 
 **ADVANCE** when:
-- The reviewer's feedback is positive or has only minor suggestions
-- The work meets the core requirements even if not perfect
-- Issues raised are cosmetic or low-priority
-- On later iterations: the work is "good enough" and further iteration would have diminishing returns
+- Feedback is positive or minor
+- Meaningful concerns are addressed
+- Work meets core requirements
 
 **ITERATE** when:
-- The reviewer identifies significant gaps or errors
-- Critical functionality is missing or broken
-- The work doesn't address the core issue requirements
-- Tests are failing or the code doesn't compile
-- The work introduces changes not required by the issue (scope creep)
-- The reviewer flags out-of-scope additions
-- Multiple documentation files created when one would suffice
-- Commit history shows "fix previous commit" pattern (e.g., "Fix lint error", "Fix test failure") — the agent should squash or rebase
+- Meaningful concerns are unaddressed
+- Critical functionality is missing
+- Scope creep must be removed
 
 **BLOCKED** when:
-- The reviewer identifies issues that require human intervention
-- External dependencies or credentials are missing
-- Requirements are ambiguous and need clarification
-- The problem is fundamentally unsolvable with the current approach
+- Human intervention required
+- Requirements ambiguous
 
 ### Iteration Awareness
 

--- a/prompts/skills/plan_reviewer.md
+++ b/prompts/skills/plan_reviewer.md
@@ -4,12 +4,13 @@ You are reviewing a **plan** produced by an agent. Your role is to provide const
 
 ### Evaluation Criteria
 
-- **Specificity:** Does the plan reference concrete file paths, function names, and line numbers where changes will be made?
-- **Completeness:** Does the plan address all aspects of the issue? Are there missing steps or overlooked edge cases?
-- **Ordering:** Are the steps in a logical order? Are dependencies between steps correctly sequenced?
-- **Testability:** Does the plan include a testing strategy? Can the implementation be verified?
-- **Feasibility:** Is the plan realistic given the codebase structure? Are there any architectural issues?
-- **Scope:** Does the plan stay within the issue requirements? Are there proposed changes that aren't necessary to close the issue? Flag any "scope creep" — features, refactoring, or documentation not explicitly requested.
+- **Issue Alignment:** Does the plan address the issue requirements?
+- **Approach:** Is this a reasonable approach? Are there obvious better alternatives?
+- **Completeness:** Are necessary steps identified?
+- **Feasibility:** Will this work given the codebase?
+- **Scope:** Does the plan stay within issue requirements?
+
+Plans describe approach, not implementation code. Do not request code snippets, line numbers, or low-level details.
 
 ### Guidelines
 


### PR DESCRIPTION
## Summary

- Updated `plan_reviewer.md` to focus on high-level approach evaluation instead of requesting low-level details like code snippets and line numbers
- Updated `judge.md` to use a two-step filtering process before deciding on a verdict

## Problem

The judge was requesting ITERATE for concerns that were either:
- Already addressed in the plan
- Implementation details that don't belong in the PLAN phase (e.g., requesting code snippets)

## Changes

**Plan Reviewer** (`prompts/skills/plan_reviewer.md`):
- Simplified evaluation criteria to focus on: issue alignment, approach, completeness, feasibility, scope
- Added explicit instruction: "Do not request code snippets, line numbers, or low-level details"

**Judge** (`prompts/skills/judge.md`):
- Replaced "Decision Rubric" with "Decision Process"
- Added Step 1: Filter reviewer concerns (is this meaningful for the phase? is it already addressed?)
- Added Step 2: Decide based on filtered concerns
- Streamlined ADVANCE/ITERATE/BLOCKED criteria

## Test plan

- [ ] Re-run issue #155 test case
- [ ] Expected: Judge filters "code snippets" as not meaningful for PLAN, returns ADVANCE

🤖 Generated with [Claude Code](https://claude.com/claude-code)