### PR TITLE
Fix clone URL handling for both repo formats

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -751,8 +751,14 @@ func (c *Controller) cloneRepository(ctx context.Context) error {
 	// Parse repository URL
 	repo := c.config.Repository
 	if !strings.HasPrefix(repo, "https://") && !strings.HasPrefix(repo, "git@") {
-		// Handle owner/repo shorthand format (e.g., "andymwolf/agentium")
-		repo = "https://github.com/" + repo
+		// Handle various shorthand formats:
+		// - "owner/repo" -> "https://github.com/owner/repo"
+		// - "github.com/owner/repo" -> "https://github.com/owner/repo"
+		if strings.HasPrefix(repo, "github.com/") {
+			repo = "https://" + repo
+		} else {
+			repo = "https://github.com/" + repo
+		}
 	}
 
 	// Clone with token authentication


### PR DESCRIPTION
## Summary
- Fixes clone URL construction to handle both repository formats:
  - `owner/repo` → `https://github.com/owner/repo`
  - `github.com/owner/repo` → `https://github.com/owner/repo`
- Previous fix (#222) caused double domain: `https://github.com/github.com/owner/repo`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy and verify cloud sessions with both repo formats clone successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)