### PR TITLE
Exclude safety skill from judge phases

### DIFF
--- a/prompts/skills/loader_test.go
+++ b/prompts/skills/loader_test.go
@@ -45,7 +45,7 @@ func TestLoadManifest_Phases(t *testing.T) {
 		name       string
 		wantPhases []string
 	}{
-		{"safety", nil},
+		{"safety", []string{"PLAN", "IMPLEMENT", "REVIEW", "DOCS", "PR_CREATION", "ANALYZE", "PUSH", "PLAN_REVIEW", "IMPLEMENT_REVIEW", "REVIEW_REVIEW", "DOCS_REVIEW"}},
 		{"environment", nil},
 		{"status_signals", nil},
 		{"planning", []string{"IMPLEMENT", "ANALYZE"}},

--- a/prompts/skills/manifest.yaml
+++ b/prompts/skills/manifest.yaml
@@ -7,7 +7,18 @@ skills:
   - name: safety
     file: safety.md
     priority: 10
-    phases: []
+    phases:
+      - PLAN
+      - IMPLEMENT
+      - REVIEW
+      - DOCS
+      - PR_CREATION
+      - ANALYZE
+      - PUSH
+      - PLAN_REVIEW
+      - IMPLEMENT_REVIEW
+      - REVIEW_REVIEW
+      - DOCS_REVIEW
 
   - name: environment
     file: environment.md


### PR DESCRIPTION
## Summary

- Fixed bug where the judge was demanding branch creation before advancing from PLAN phase
- The safety skill was universal (`phases: []`) and loaded into all phases including `PLAN_JUDGE`
- This caused the judge to see "ALWAYS create a feature branch" and reject plans that hadn't created branches, even though `plan.md` explicitly says "Do NOT create branches"

## Changes

- Updated `prompts/skills/manifest.yaml` to give safety explicit phases (all worker and reviewer phases, excluding judge phases)
- Updated `prompts/skills/loader_test.go` to match new configuration

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Run a PLAN phase and verify the judge no longer demands branch creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)