### PR TITLE
Add instance identifier to Agentium comments for debugging

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -194,6 +194,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 	// Build session config for the VM
 	sessionConfig := provisioner.SessionConfig{
 		ID:            sessionID,
+		CloudProvider: cfg.Cloud.Provider,
 		Repository:    cfg.Session.Repository,
 		Tasks:         cfg.Session.Tasks,
 		PRs:           cfg.Session.PRs,

--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -151,6 +151,7 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	// Build controller session config
 	sessionConfig := controller.SessionConfig{
 		ID:                   sessionID,
+		CloudProvider:        "local",
 		Repository:           cfg.Session.Repository,
 		Tasks:                cfg.Session.Tasks,
 		PRs:                  cfg.Session.PRs,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -95,8 +95,9 @@ type PhaseLoopConfig struct {
 
 // SessionConfig is the configuration passed to the controller
 type SessionConfig struct {
-	ID                   string   `json:"id"`
-	Repository           string   `json:"repository"`
+	ID            string `json:"id"`
+	CloudProvider string `json:"cloud_provider,omitempty"` // Cloud provider (gcp, aws, azure, local)
+	Repository    string `json:"repository"`
 	Tasks                []string `json:"tasks"`
 	PRs                  []string `json:"prs,omitempty"`
 	Agent                string   `json:"agent"`

--- a/internal/controller/draft_pr.go
+++ b/internal/controller/draft_pr.go
@@ -97,7 +97,8 @@ This is a draft PR - implementation is in progress.
 - [ ] Documentation updated
 
 ---
-*This draft PR was automatically created by Agentium during the IMPLEMENT phase.*`, issueNumber)
+*This draft PR was automatically created by Agentium during the IMPLEMENT phase.*
+*Instance: %s*`, issueNumber, c.instanceSignature())
 
 	c.logInfo("Creating draft PR for issue #%s", issueNumber)
 	createCmd := exec.CommandContext(ctx, "gh", "pr", "create",

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -50,8 +50,9 @@ type CodexAuthConfig struct {
 
 // SessionConfig contains the session configuration to pass to the VM
 type SessionConfig struct {
-	ID            string                `json:"id"`
-	Repository    string                `json:"repository"`
+	ID            string `json:"id"`
+	CloudProvider string `json:"cloud_provider,omitempty"` // Cloud provider (gcp, aws, azure)
+	Repository    string `json:"repository"`
 	Tasks         []string              `json:"tasks"`
 	PRs           []string              `json:"prs,omitempty"`
 	Agent         string                `json:"agent"`


### PR DESCRIPTION
## Summary

- Adds cloud provider and session ID (e.g., `gcp:agentium-ede23a28`) to all Agentium comments on GitHub Issues/PRs for easier debugging
- Instance identifier helps trace which VM/session posted a specific comment

## Changes

- Add `CloudProvider` field to `SessionConfig` in both controller and provisioner
- Pass cloud provider from CLI to controller (`gcp`/`aws`/`azure` for cloud, `local` for `run --local` mode)
- Add `instanceSignature()` and `appendSignature()` helper methods to controller
- Append instance signature as HTML comment footer to all issue and PR comments (invisible in rendered markdown)
- Add visible instance info to draft PR body footer

## Format

Comments include an HTML comment footer (invisible in rendered markdown):
```markdown
[Comment body]

<!-- agentium:gcp:agentium-ede23a28 -->
```

Draft PR body includes visible footer:
```markdown
*Instance: agentium:gcp:agentium-ede23a28*
```

## Test plan

- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./internal/controller/... -v`
- [x] Linter passes: `go vet ./...`
- [ ] Manual test with local mode to verify signature appears in comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)