### PR TITLE
Remove planning skill from IMPLEMENT phase

### DIFF
--- a/prompts/skills/loader_test.go
+++ b/prompts/skills/loader_test.go
@@ -48,7 +48,7 @@ func TestLoadManifest_Phases(t *testing.T) {
 		{"safety", []string{"PLAN", "IMPLEMENT", "DOCS", "ANALYZE", "PUSH", "PLAN_REVIEW", "IMPLEMENT_REVIEW", "DOCS_REVIEW"}}, // PR_CREATION removed
 		{"environment", nil},
 		{"status_signals", nil},
-		{"planning", []string{"IMPLEMENT", "ANALYZE"}},
+		{"planning", []string{"ANALYZE"}},
 		{"plan", []string{"PLAN"}},
 		{"implement", []string{"IMPLEMENT"}},
 		{"test", []string{"IMPLEMENT"}},                                              // TEST merged into IMPLEMENT

--- a/prompts/skills/manifest.yaml
+++ b/prompts/skills/manifest.yaml
@@ -31,7 +31,6 @@ skills:
     file: planning.md
     priority: 40
     phases:
-      - IMPLEMENT
       - ANALYZE
 
   - name: plan

--- a/prompts/skills/selector_test.go
+++ b/prompts/skills/selector_test.go
@@ -20,7 +20,7 @@ func newTestSkills() []Skill {
 			Content: "STATUS_SIGNALS CONTENT",
 		},
 		{
-			Entry:   SkillEntry{Name: "planning", File: "planning.md", Priority: 40, Phases: []string{"IMPLEMENT", "ANALYZE"}},
+			Entry:   SkillEntry{Name: "planning", File: "planning.md", Priority: 40, Phases: []string{"ANALYZE"}},
 			Content: "PLANNING CONTENT",
 		},
 		{
@@ -47,15 +47,15 @@ func TestSelector_SelectForPhase_Implement(t *testing.T) {
 	result := s.SelectForPhase("IMPLEMENT")
 
 	// Should include universal skills + IMPLEMENT-phase skills
-	expected := []string{"SAFETY CONTENT", "ENVIRONMENT CONTENT", "STATUS_SIGNALS CONTENT", "PLANNING CONTENT", "IMPLEMENT CONTENT", "TEST CONTENT"}
+	expected := []string{"SAFETY CONTENT", "ENVIRONMENT CONTENT", "STATUS_SIGNALS CONTENT", "IMPLEMENT CONTENT", "TEST CONTENT"}
 	for _, exp := range expected {
 		if !strings.Contains(result, exp) {
 			t.Errorf("SelectForPhase(IMPLEMENT) missing %q", exp)
 		}
 	}
 
-	// Should NOT include PR-specific skills
-	excluded := []string{"PR CREATION CONTENT", "PR REVIEW CONTENT"}
+	// Should NOT include planning or PR-specific skills
+	excluded := []string{"PLANNING CONTENT", "PR CREATION CONTENT", "PR REVIEW CONTENT"}
 	for _, exc := range excluded {
 		if strings.Contains(result, exc) {
 			t.Errorf("SelectForPhase(IMPLEMENT) should not contain %q", exc)
@@ -164,7 +164,6 @@ func TestSelector_SelectForPhase_PriorityOrder(t *testing.T) {
 	safetyIdx := strings.Index(result, "SAFETY CONTENT")
 	envIdx := strings.Index(result, "ENVIRONMENT CONTENT")
 	statusIdx := strings.Index(result, "STATUS_SIGNALS CONTENT")
-	planningIdx := strings.Index(result, "PLANNING CONTENT")
 	implementIdx := strings.Index(result, "IMPLEMENT CONTENT")
 	testIdx := strings.Index(result, "TEST CONTENT")
 
@@ -174,11 +173,8 @@ func TestSelector_SelectForPhase_PriorityOrder(t *testing.T) {
 	if envIdx > statusIdx {
 		t.Error("environment should come before status_signals")
 	}
-	if statusIdx > planningIdx {
-		t.Error("status_signals should come before planning")
-	}
-	if planningIdx > implementIdx {
-		t.Error("planning should come before implement")
+	if statusIdx > implementIdx {
+		t.Error("status_signals should come before implement")
 	}
 	if implementIdx > testIdx {
 		t.Error("implement should come before test")
@@ -192,7 +188,7 @@ func TestSelector_SkillsForPhase(t *testing.T) {
 		phase    string
 		expected []string
 	}{
-		{"IMPLEMENT", []string{"safety", "environment", "status_signals", "planning", "implement", "test"}},
+		{"IMPLEMENT", []string{"safety", "environment", "status_signals", "implement", "test"}},
 		{"TEST", []string{"safety", "environment", "status_signals", "test"}},
 		{"ANALYZE", []string{"safety", "environment", "status_signals", "planning", "pr_review"}},
 		{"PR_CREATION", []string{"safety", "environment", "status_signals", "pr_creation"}},
@@ -222,8 +218,8 @@ func TestSelector_SelectForPhase_Separator(t *testing.T) {
 
 	// Verify parts are separated by double newlines
 	parts := strings.Split(result, "\n\n")
-	if len(parts) < 6 {
-		t.Errorf("Expected at least 6 parts separated by double newlines, got %d", len(parts))
+	if len(parts) < 5 {
+		t.Errorf("Expected at least 5 parts separated by double newlines, got %d", len(parts))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removed `IMPLEMENT` from the planning skill phases in `manifest.yaml`
- Updated tests in `selector_test.go` and `loader_test.go` to reflect this change

**Root cause:** The `planning.md` skill (priority 40) was included in IMPLEMENT phase. It contains "Step 1: Understand the Issue" and "Step 2: Plan Your Approach" - but by IMPLEMENT phase, the PLAN phase has already completed. The agent followed these stale planning instructions instead of executing.

**Why this works:** The PLAN phase already provides the plan via structured handoff context. Without `planning.md`, the IMPLEMENT phase only gets `implement.md` which starts at "Pre-Flight Check". The agent will naturally explore code when needed (like Claude Code does) without being told to "Plan Your Approach".

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./prompts/skills/...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)