### PR TITLE
Pre-install Go in Docker image to eliminate startup delay

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -14,6 +14,13 @@ RUN apt-get update && apt-get install -y \
     sudo \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Go (pre-installed to avoid download delay at container startup)
+ENV GO_VERSION=1.22.0
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/docker/scripts/install-runtime.sh
+++ b/docker/scripts/install-runtime.sh
@@ -16,6 +16,13 @@ file_exists() {
 # Function to install Go
 install_go() {
     log "Detected Go project (go.mod found)"
+
+    # Check if Go is already installed (pre-installed in Docker image)
+    if command -v go &> /dev/null; then
+        log "Go already installed: $(go version)"
+        return
+    fi
+
     log "Installing Go runtime..."
 
     # Download and install Go


### PR DESCRIPTION
## Summary

- Pre-install Go 1.22.0 in the Docker image during build time instead of downloading at container startup
- Update `install-runtime.sh` to skip Go installation if already present
- Eliminates 10-60+ second delay between "mounting oauth credentials" and agent startup for Go projects

## Test plan

- [ ] Build Docker image locally: `docker build -f docker/claudecode/Dockerfile -t agentium-claudecode:latest .`
- [ ] Verify Go is installed: `docker run --rm agentium-claudecode:latest go version`
- [ ] Test with Go project and verify logs show "Go already installed" instead of download messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)