### PR TITLE
Remove NoMergeVerdictGiven field and update WORKFLOW.md

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -87,20 +87,19 @@ const (
 
 // TaskState tracks the current state of a task being worked on
 type TaskState struct {
-	ID                  string
-	Type                string // "issue" or "pr"
-	Phase               TaskPhase
-	TestRetries         int
-	LastStatus          string
-	PRNumber            string       // Linked PR number (for issues that create PRs)
-	PhaseIteration      int          // Current iteration within the active phase (phase loop)
-	MaxPhaseIter        int          // Max iterations for current phase (phase loop)
-	LastJudgeVerdict    string       // Last judge verdict (ADVANCE, ITERATE, BLOCKED)
-	LastJudgeFeedback   string       // Last judge feedback text
-	DraftPRCreated      bool         // Whether draft PR has been created for this task
-	WorkflowPath        WorkflowPath // Set after PLAN iteration 1 (SIMPLE or COMPLEX)
-	ControllerOverrode  bool         // True if controller forced ADVANCE at max iterations
-	NoMergeVerdictGiven bool         // True if NOMERGE verdict given during final review
+	ID                 string
+	Type               string // "issue" or "pr"
+	Phase              TaskPhase
+	TestRetries        int
+	LastStatus         string
+	PRNumber           string       // Linked PR number (for issues that create PRs)
+	PhaseIteration     int          // Current iteration within the active phase (phase loop)
+	MaxPhaseIter       int          // Max iterations for current phase (phase loop)
+	LastJudgeVerdict   string       // Last judge verdict (ADVANCE, ITERATE, BLOCKED)
+	LastJudgeFeedback  string       // Last judge feedback text
+	DraftPRCreated     bool         // Whether draft PR has been created for this task
+	WorkflowPath       WorkflowPath // Set after PLAN iteration 1 (SIMPLE or COMPLEX)
+	ControllerOverrode bool         // True if controller forced ADVANCE at max iterations (triggers NOMERGE)
 }
 
 // PhaseLoopConfig controls the controller-as-judge phase loop behavior.

--- a/internal/controller/draft_pr.go
+++ b/internal/controller/draft_pr.go
@@ -254,12 +254,9 @@ func (c *Controller) finalizeDraftPR(ctx context.Context, taskID string) error {
 		return nil
 	}
 
-	// Check if NOMERGE handling is needed
-	if state.ControllerOverrode || state.NoMergeVerdictGiven {
+	// Check if NOMERGE handling is needed (controller forced ADVANCE at max iterations)
+	if state.ControllerOverrode {
 		reason := "Controller forced ADVANCE at max iterations"
-		if state.NoMergeVerdictGiven {
-			reason = "NOMERGE verdict was given during review"
-		}
 		c.logWarning("PR #%s requires human review: %s", state.PRNumber, reason)
 		c.postNOMERGEComment(ctx, state.PRNumber, reason)
 		// Keep PR as draft - do not mark as ready


### PR DESCRIPTION
## Summary

- Remove redundant `NoMergeVerdictGiven` from TaskState since `ControllerOverrode` already handles the NOMERGE case
- Simplify `finalizeDraftPR` to only check `ControllerOverrode`
- Update WORKFLOW.md diagram to show Complexity Assessor flow
- Document that SIMPLE/COMPLEX are Complexity Assessor verdicts, not Judge verdicts
- Document NOMERGE as a controller behavior, not a verdict

## Test plan

- [x] Build passes: `go build ./...`
- [x] All controller tests pass: `go test ./internal/controller/...`

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)