### PR TITLE
Replace npm with bun for faster container builds

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -31,8 +31,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
+# Install bun for faster package installation
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
 # Install Claude Code CLI
-RUN npm install -g @anthropic-ai/claude-code
+RUN bun add -g @anthropic-ai/claude-code
 
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium

--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -24,8 +24,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
+# Install bun for faster package installation
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
 # Install Codex CLI
-RUN npm install -g @openai/codex
+RUN bun add -g @openai/codex
 
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium

--- a/docs/cloud-setup/gcp.md
+++ b/docs/cloud-setup/gcp.md
@@ -72,7 +72,7 @@ If using the Codex agent, authenticate on a machine with a browser first:
 
 ```bash
 # Install Codex
-npm install -g @openai/codex
+bun add -g @openai/codex
 
 # Login (opens browser for OAuth)
 codex --login

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,7 +157,7 @@ codex:
   auth_json_path: "~/.codex/auth.json"
 ```
 
-> **Note:** To set up Codex credentials, install Codex (`npm install -g @openai/codex`) and run `codex --login`. Agentium reads the cached credentials and transfers them to the VM automatically.
+> **Note:** To set up Codex credentials, install Codex (`bun add -g @openai/codex`) and run `codex --login`. Agentium reads the cached credentials and transfers them to the VM automatically.
 
 ### claude
 
@@ -171,7 +171,7 @@ codex:
 - **`api`** - Uses the `ANTHROPIC_API_KEY` environment variable. Simple setup, requires a long-lived API key.
 - **`oauth`** - Uses Claude Code OAuth credentials from an `auth.json` file. More secure for local usage. On macOS, Agentium will also check the macOS Keychain for Claude Code credentials if the file is not found.
 
-> **Note:** OAuth auth mode is only supported with the `claude-code` agent. To set up OAuth credentials, install Claude Code (`npm install -g @anthropic-ai/claude-code`) and run `claude login`.
+> **Note:** OAuth auth mode is only supported with the `claude-code` agent. To set up OAuth credentials, install Claude Code (`bun add -g @anthropic-ai/claude-code`) and run `claude login`.
 
 ### controller
 

--- a/internal/audit/classify.go
+++ b/internal/audit/classify.go
@@ -29,10 +29,11 @@ var sensitivePathPatterns = []*regexp.Regexp{
 
 // packageInstallPatterns matches commands that install packages.
 var packageInstallPatterns = []*regexp.Regexp{
-	// npm/yarn/pnpm
+	// npm/yarn/pnpm/bun
 	regexp.MustCompile(`(?i)\bnpm\s+(install|i|add|ci)\b`),
 	regexp.MustCompile(`(?i)\byarn\s+(add|install)\b`),
 	regexp.MustCompile(`(?i)\bpnpm\s+(add|install|i)\b`),
+	regexp.MustCompile(`(?i)\bbun\s+(add|install|i)\b`),
 	// pip/pipx
 	regexp.MustCompile(`(?i)\bpip3?\s+install\b`),
 	regexp.MustCompile(`(?i)\bpipx?\s+install\b`),

--- a/internal/audit/classify_test.go
+++ b/internal/audit/classify_test.go
@@ -121,6 +121,13 @@ func TestIsPackageInstall(t *testing.T) {
 		{"pnpm i", true},
 		{"pnpm test", false},
 
+		// bun
+		{"bun add express", true},
+		{"bun install", true},
+		{"bun i", true},
+		{"bun run build", false},
+		{"bun test", false},
+
 		// pip
 		{"pip install requests", true},
 		{"pip3 install flask", true},

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -366,7 +366,7 @@ func readAuthJSON(path string) ([]byte, error) {
 					return keychainData, nil
 				}
 			}
-			return nil, fmt.Errorf("auth.json not found at %s and not in macOS Keychain\n\nTo use OAuth authentication:\n  1. Install Claude Code: npm install -g @anthropic-ai/claude-code\n  2. Run: claude login\n  3. Try again", path)
+			return nil, fmt.Errorf("auth.json not found at %s and not in macOS Keychain\n\nTo use OAuth authentication:\n  1. Install Claude Code: bun add -g @anthropic-ai/claude-code\n  2. Run: claude login\n  3. Try again", path)
 		}
 		return nil, fmt.Errorf("failed to read auth.json: %w", err)
 	}
@@ -430,7 +430,7 @@ func readCodexAuthJSON(path string) ([]byte, error) {
 					return keychainData, nil
 				}
 			}
-			return nil, fmt.Errorf("codex auth.json not found at %s and not in macOS Keychain\n\nTo use Codex authentication:\n  1. Install Codex: npm install -g @openai/codex\n  2. Run: codex --login\n  3. Try again", path)
+			return nil, fmt.Errorf("codex auth.json not found at %s and not in macOS Keychain\n\nTo use Codex authentication:\n  1. Install Codex: bun add -g @openai/codex\n  2. Run: codex --login\n  3. Try again", path)
 		}
 		return nil, fmt.Errorf("failed to read Codex auth.json: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Install bun in container images and use `bun add -g` instead of `npm install -g` for CLI tool installation
- Update install instructions in error messages and documentation to use bun
- Add bun detection patterns (`bun add`, `bun install`, `bun i`) to audit package for tracking package installs

## Test plan
- [x] Build passes: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] New bun test cases added and passing
- [ ] Docker build verification (manual)

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)