### PR TITLE
Fix scanner and parser bugs from PR #258 review

### DIFF
--- a/internal/agentmd/generator.go
+++ b/internal/agentmd/generator.go
@@ -78,8 +78,8 @@ func (g *Generator) WriteToProject(rootDir string, info *scanner.ProjectInfo) er
 		return fmt.Errorf("failed to parse existing AGENT.md: %w", err)
 	}
 
-	// Combine new generated content with preserved custom content
-	finalContent := newContent
+	// Combine preserved pre-content, new generated content, and preserved custom content
+	finalContent := parsed.PreContent + newContent
 	if parsed.CustomContent != "" {
 		finalContent += parsed.CustomContent
 	} else {

--- a/internal/agentmd/parser.go
+++ b/internal/agentmd/parser.go
@@ -6,8 +6,9 @@ import (
 
 // ParsedContent represents the parsed sections of an AGENT.md file.
 type ParsedContent struct {
+	PreContent       string // Content before the generated section
 	GeneratedContent string
-	CustomContent    string
+	CustomContent    string // Content after the generated section
 	HasMarkers       bool
 }
 
@@ -29,6 +30,11 @@ func (p *Parser) Parse(content string) (*ParsedContent, error) {
 	}
 
 	result.HasMarkers = true
+
+	// Extract content before the generated section
+	if startIdx > 0 {
+		result.PreContent = content[:startIdx]
+	}
 
 	// Extract generated content (including markers)
 	result.GeneratedContent = content[startIdx : endIdx+len(GeneratedEndMarker)]

--- a/internal/scanner/build.go
+++ b/internal/scanner/build.go
@@ -126,9 +126,12 @@ func detectNodeBuild(rootDir string) buildSystemInfo {
 		info.name = "bun"
 	}
 
+	// Determine the command prefix for running package.json scripts.
+	// npm and bun require "run" to execute scripts (e.g., "npm run test", "bun run test").
+	// yarn and pnpm can run scripts directly (e.g., "yarn test", "pnpm test").
 	runner := info.name
-	if runner == "npm" {
-		runner = "npm run"
+	if runner == "npm" || runner == "bun" {
+		runner = info.name + " run"
 	}
 
 	// Detect build commands


### PR DESCRIPTION
## Summary

- Preserve content before `<!-- agentium:generated:start -->` marker during AGENT.md refresh
- Make Go framework detection deterministic using ordered priority list
- Use `bun run <script>` for Bun projects instead of `bun <script>`

## Test plan

- [ ] Verify `agentium refresh` preserves custom headers/content placed above the generated section
- [ ] Verify framework detection is consistent across multiple runs for projects with gin+cobra
- [ ] Verify Bun projects generate `bun run test` instead of `bun test`

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)