### PR TITLE
Fix reviewer comment formatting to exclude reasoning preamble

### DIFF
--- a/internal/controller/reviewer.go
+++ b/internal/controller/reviewer.go
@@ -150,7 +150,14 @@ func (c *Controller) buildReviewPrompt(params reviewRunParams) string {
 
 	sb.WriteString("## Your Task\n\n")
 	sb.WriteString("Provide constructive, actionable review feedback on the phase output above.\n")
-	sb.WriteString("Be specific about what to improve. Do NOT emit any verdict — your role is to provide feedback only.\n")
+	sb.WriteString("Be specific about what to improve. Do NOT emit any verdict — your role is to provide feedback only.\n\n")
+
+	sb.WriteString("## Output Format\n\n")
+	sb.WriteString("**CRITICAL:** Output ONLY your feedback. Do NOT include:\n")
+	sb.WriteString("- Preamble or planning statements (e.g., \"I need to review...\", \"Let me examine...\")\n")
+	sb.WriteString("- Descriptions of your process or reasoning\n")
+	sb.WriteString("- Issue or PR metadata\n\n")
+	sb.WriteString("Start directly with your feedback content. Use concise bullet points or short paragraphs.\n")
 
 	// Add comparison task if we have previous feedback
 	if params.Iteration > 1 && params.PreviousFeedback != "" {


### PR DESCRIPTION
## Summary

- Fix bug where reviewer agent's internal reasoning (e.g., "I need to review the IMPLEMENT phase output...") was being included in GitHub comments
- Add explicit formatting instructions to the reviewer prompt to output only the feedback content

## Problem

Review comments posted to GitHub issues/PRs were including the model's chain-of-thought reasoning text before the actual feedback content, causing confusing and poorly formatted comments like:

```
### Review Summary: IMPLEMENT (iteration 1)

I need to review the IMPLEMENT phase output for issue #268. Let me first understand what issue #268 requires, then examine the changes made.
title:    Add constants and fix type safety issues in controller.go
...
```

## Solution

Updated `buildReviewPrompt()` in `internal/controller/reviewer.go` to add an "Output Format" section that explicitly instructs the model to:
- NOT include preamble or planning statements
- NOT include descriptions of its process or reasoning  
- NOT include issue or PR metadata
- Start directly with feedback content

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy and verify review comments no longer include reasoning preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)