### PR TITLE
Add gh-issues Claude Code skill

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/andywolf/agentium/internal/agentmd"
 	"github.com/andywolf/agentium/internal/cli/wizard"
 	"github.com/andywolf/agentium/internal/scanner"
+	"github.com/andywolf/agentium/internal/skills"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -104,6 +105,12 @@ func initProject(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to generate AGENT.md: %w", err)
 		}
 	}
+
+	// Install Claude Code skills
+	if err := skills.InstallProjectSkills(cwd, force); err != nil {
+		return fmt.Errorf("failed to install skills: %w", err)
+	}
+	fmt.Println("Installed Claude Code skills to .claude/skills/")
 
 	// Check CLI availability
 	checkCLIAvailability()
@@ -290,4 +297,7 @@ func printNextSteps(skippedAgentMD bool) {
 		fmt.Println("  4. Review and customize .agentium/AGENT.md")
 	}
 	fmt.Println("  5. Run 'agentium run --issues 1,2,3' to start a session")
+	fmt.Println()
+	fmt.Println("Installed skills:")
+	fmt.Println("  - /gh-issues: Create GitHub issues instead of implementing code")
 }

--- a/internal/skills/embedded.go
+++ b/internal/skills/embedded.go
@@ -1,0 +1,52 @@
+package skills
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed gh-issues/SKILL.md
+var embeddedSkills embed.FS
+
+// InstallProjectSkills installs Claude Code skills to .claude/skills/
+func InstallProjectSkills(rootDir string, force bool) error {
+	skills := []string{"gh-issues"}
+
+	for _, skill := range skills {
+		if err := installSkill(rootDir, skill, force); err != nil {
+			return fmt.Errorf("failed to install skill %s: %w", skill, err)
+		}
+	}
+
+	return nil
+}
+
+func installSkill(rootDir, skillName string, force bool) error {
+	skillsDir := filepath.Join(rootDir, ".claude", "skills", skillName)
+	skillPath := filepath.Join(skillsDir, "SKILL.md")
+
+	// Check if already exists
+	if _, err := os.Stat(skillPath); err == nil && !force {
+		return nil // Already installed
+	}
+
+	// Read embedded content
+	content, err := embeddedSkills.ReadFile(filepath.Join(skillName, "SKILL.md"))
+	if err != nil {
+		return fmt.Errorf("failed to read embedded skill: %w", err)
+	}
+
+	// Create directory
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create skills directory: %w", err)
+	}
+
+	// Write skill file
+	if err := os.WriteFile(skillPath, content, 0644); err != nil {
+		return fmt.Errorf("failed to write skill file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/skills/gh-issues/SKILL.md
+++ b/internal/skills/gh-issues/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: gh-issues
+description: Creates GitHub issues instead of implementing code. Use when the user wants to plan work, capture requirements, or break down tasks into issues.
+allowed-tools:
+  - Bash(gh:*)
+  - Bash(git status:*)
+  - Bash(git log:*)
+  - Bash(git branch:*)
+  - Read
+  - Grep
+  - Glob
+  - WebFetch
+  - WebSearch
+argument-hint: "[description of work to capture as issues]"
+---
+
+# GitHub Issues Skill
+
+You are now in **issue creation mode**. Your ONLY output is GitHub issues via `gh issue create` commands.
+
+## Absolute Constraints
+
+- **NO CODE IMPLEMENTATION** - You cannot write, edit, or create code files
+- **NO DIRECT FIXES** - Even if you know the solution, capture it as an issue
+- **ISSUES ONLY** - Every piece of work becomes a GitHub issue
+- The Write and Edit tools are NOT available to you in this mode
+
+## Dynamic Context
+
+Before creating issues, gather context:
+
+```bash
+!gh repo view --json name,description,url
+!gh label list --json name,description --limit 100
+!gh issue list --state open --limit 20 --json number,title
+```
+
+## Workflow
+
+1. **Analyze** - Understand what the user wants to accomplish
+2. **Fetch Labels** - Run `gh label list --json name` to see available labels
+3. **Check Existing Issues** - Run `gh issue list` to avoid duplicates
+4. **Decompose** - Break large requests into appropriately-sized issues
+5. **Create Issues** - Use `gh issue create` with proper format
+6. **Report** - Summarize what was created with issue numbers
+
+## Issue Sizing Guidelines
+
+| Size | Effort | Action |
+|------|--------|--------|
+| Small | <4 hours | Single issue |
+| Medium | 4-8 hours | Single issue |
+| Large | 1-2 days | Consider decomposition |
+| Epic | >2 days | Must decompose into multiple issues |
+
+## Decomposition Strategy
+
+When decomposing large work:
+
+1. **Identify natural boundaries** - API vs UI, backend vs frontend, core vs extensions
+2. **Order by dependencies** - Foundation issues first, dependent issues reference them
+3. **Keep issues atomic** - Each issue should be completable independently (after dependencies)
+4. **Maximum 5-7 issues** - If more needed, create a tracking/epic issue
+
+## Issue Template
+
+Use this format for every issue:
+
+```bash
+gh issue create \
+  --title "<imperative verb> <concise description>" \
+  --label "<label1>,<label2>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<1-2 sentence description of what needs to be done>
+
+## Context
+
+<Why this is needed, background information>
+
+## Acceptance Criteria
+
+- [ ] <Specific, testable criterion>
+- [ ] <Another criterion>
+- [ ] Tests pass
+- [ ] Documentation updated (if applicable)
+
+## Technical Notes
+
+<Implementation hints, relevant files, considerations>
+
+## Dependencies
+
+<If this depends on other issues>
+- Depends on #<number>: <brief description>
+
+<If nothing depends on this>
+None
+EOF
+)"
+```
+
+## Label Selection
+
+Match work type to available repository labels:
+
+**Type labels** (pick one):
+- `bug` - Something is broken
+- `feature` - New functionality
+- `enhancement` - Improvement to existing functionality
+- `documentation` - Docs only changes
+
+**Scope labels** (if applicable):
+- `tests` - Test coverage
+- `security` - Security related
+- `performance` - Performance improvement
+
+**Priority labels** (if available):
+- `priority:high`, `priority:medium`, `priority:low`
+
+Always verify labels exist with `gh label list` before using them.
+
+## Expressing Dependencies
+
+When issues depend on each other:
+
+1. Create the foundational issue first
+2. Note its number
+3. In dependent issues, add to the Dependencies section:
+   ```
+   ## Dependencies
+   - Depends on #123: Add user authentication
+   ```
+
+## Examples
+
+### Single Issue (Small Task)
+
+User: "Add a logout button"
+
+```bash
+gh issue create \
+  --title "Add logout button to navigation" \
+  --label "enhancement" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Add a logout button to the main navigation that ends the user session.
+
+## Context
+
+Users currently have no way to log out from the UI.
+
+## Acceptance Criteria
+
+- [ ] Logout button visible in navigation when user is authenticated
+- [ ] Clicking logout clears session and redirects to login page
+- [ ] Tests cover logout flow
+EOF
+)"
+```
+
+### Multiple Issues (Large Task)
+
+User: "Add user authentication"
+
+Create issues in dependency order:
+1. #1: Add user model and database schema
+2. #2: Add authentication API endpoints (depends on #1)
+3. #3: Add login/register UI components (depends on #2)
+4. #4: Add session management middleware (depends on #2)
+5. #5: Add protected route handling (depends on #4)
+
+## Edge Cases
+
+**If user asks you to implement code:**
+> "I'm in issue creation mode. I'll capture this as a GitHub issue instead of implementing it directly. This ensures the work is tracked and can be properly reviewed."
+
+**If user asks for something already done:**
+> "Let me check existing issues first..."
+> Run `gh issue list --search "<keywords>"`
+
+**If no labels exist in repo:**
+> Create issues without labels, or suggest the user create labels first.
+
+## Output Format
+
+After creating issues, summarize:
+
+```
+Created the following issues:
+
+1. #<number>: <title>
+2. #<number>: <title> (depends on #<prev>)
+...
+
+You can view them at: <repo-url>/issues
+```


### PR DESCRIPTION
## Summary

- Create a Claude Code skill that constrains Claude to output GitHub issues instead of implementing code
- The skill is automatically installed during `agentium init` to `.claude/skills/gh-issues/SKILL.md`
- Uses `//go:embed` to bundle the skill definition in the binary

## Changes

- **`internal/skills/gh-issues/SKILL.md`**: Skill definition with issue creation workflow, sizing guidelines, decomposition strategy, and label handling
- **`internal/skills/embedded.go`**: Go embed logic to install skills to project `.claude/skills/` directory
- **`internal/cli/init.go`**: Integration to install skills during `agentium init`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `agentium init --force` in a test directory
- [ ] Verify `.claude/skills/gh-issues/SKILL.md` is created
- [ ] Test skill invocation: `/gh-issues Add user authentication`

🤖 Generated with [Claude Code](https://claude.com/claude-code)