### PR TITLE
Fix claudecode Docker build by adding missing unzip dependency

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     build-essential \
     sudo \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go (pre-installed to avoid download delay at container startup)


### PR DESCRIPTION
## Summary
- Adds `unzip` to the system dependencies in the claudecode Dockerfile
- The bun installer requires `unzip` to extract the binary, which was causing CI failures

## Test plan
- [ ] Verify the Docker image builds successfully in CI
- [ ] Verify the claudecode agent container starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)