### PR TITLE
Fix codex Docker build by adding missing unzip dependency

### DIFF
--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     build-essential \
     sudo \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI


### PR DESCRIPTION
## Summary
- Adds `unzip` to the system dependencies in the codex Dockerfile
- The bun installer requires `unzip` to extract the binary
- Follow-up to #293 which fixed the same issue for claudecode

## Test plan
- [ ] Verify the Docker image builds successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)