### PR TITLE
Fix bun-installed CLIs not accessible to non-root user

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -36,8 +36,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
-# Install Claude Code CLI
-RUN bun add -g @anthropic-ai/claude-code
+# Install Claude Code CLI and symlink to system path for non-root user access
+RUN bun add -g @anthropic-ai/claude-code && \
+    ln -s /root/.bun/bin/claude /usr/local/bin/claude
 
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium

--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -29,8 +29,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
-# Install Codex CLI
-RUN bun add -g @openai/codex
+# Install Codex CLI and symlink to system path for non-root user access
+RUN bun add -g @openai/codex && \
+    ln -s /root/.bun/bin/codex /usr/local/bin/codex
 
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium


### PR DESCRIPTION
## Summary

- Fixes `claude: not found` and `codex: not found` errors when running agent containers
- The bun migration (#256) installed CLIs to `/root/.bun/bin/` which is only accessible to root
- Containers run as `agentium` user, so the CLIs were not in PATH
- Adds symlinks to `/usr/local/bin/` so CLIs are accessible to all users

## Root Cause

Session `agentium-3aeccd05` was BLOCKED because:
```
/runtime-scripts/agent-wrapper.sh: line 23: exec: claude: not found
```

## Test plan

- [ ] Build claudecode image locally: `docker build -f docker/claudecode/Dockerfile -t test-claude .`
- [ ] Verify claude is accessible: `docker run --rm test-claude which claude`
- [ ] Build codex image locally: `docker build -f docker/codex/Dockerfile -t test-codex .`
- [ ] Verify codex is accessible: `docker run --rm test-codex which codex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)