### PR TITLE
Add --pull always to docker run to prevent stale image cache

### DIFF
--- a/internal/controller/docker.go
+++ b/internal/controller/docker.go
@@ -41,8 +41,10 @@ func (c *Controller) runAgentContainer(ctx context.Context, params containerRunP
 	}
 
 	// Build Docker arguments
+	// Use --pull always to ensure we get the latest image, avoiding stale cached images
+	// that may be missing critical fixes (e.g., bun CLI symlink fix in PR #295)
 	args := []string{
-		"run", "--rm",
+		"run", "--rm", "--pull", "always",
 		"-v", fmt.Sprintf("%s:/workspace", c.workDir),
 		"-w", "/workspace",
 	}


### PR DESCRIPTION
## Summary

- Adds `--pull always` flag to docker run commands to ensure latest images are used
- Prevents stale cached images from causing failures (like the `claude: not found` error)

## Problem

Session `agentium-ea38ecf0` failed with:
```
exec: claude: not found
```

Despite PR #295 fixing the bun CLI symlink issue, GCP VMs were running cached old images without the fix.

## Solution

Add `--pull always` to ensure Docker always checks for and pulls the latest image before running containers.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)