### PR TITLE
Fix bun CLI access: copy binary instead of symlink

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -36,9 +36,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
-# Install Claude Code CLI and symlink to system path for non-root user access
+# Install Claude Code CLI and copy to system path for non-root user access
+# Copy instead of symlink to avoid needing /root directory access
 RUN bun add -g @anthropic-ai/claude-code && \
-    ln -s /root/.bun/bin/claude /usr/local/bin/claude
+    cp /root/.bun/bin/claude /usr/local/bin/claude
 
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium

--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -29,9 +29,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
 
-# Install Codex CLI and symlink to system path for non-root user access
+# Install Codex CLI and copy to system path for non-root user access
+# Copy instead of symlink to avoid needing /root directory access
 RUN bun add -g @openai/codex && \
-    ln -s /root/.bun/bin/codex /usr/local/bin/codex
+    cp /root/.bun/bin/codex /usr/local/bin/codex
 
 # Create non-root user (remove node user which owns UID 1000 in base image)
 RUN userdel -r node && useradd -m -u 1000 agentium


### PR DESCRIPTION
## Summary

- Changes symlink to copy for claude and codex binaries
- Fixes `claude: not found` / `codex: not found` errors

## Problem

The symlink from `/usr/local/bin/claude` → `/root/.bun/bin/claude` doesn't work because the `agentium` user cannot traverse `/root/` (mode 700 by default).

## Solution

Copy the binary instead of symlinking. This:
1. Avoids needing `/root` directory access
2. Is more secure than making `/root` world-readable (chmod 755)

## Test plan

- [ ] Build claudecode image: `docker build -f docker/claudecode/Dockerfile -t test .`
- [ ] Verify: `docker run --rm test which claude` returns `/usr/local/bin/claude`
- [ ] Build codex image: `docker build -f docker/codex/Dockerfile -t test .`
- [ ] Verify: `docker run --rm test which codex` returns `/usr/local/bin/codex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)