### PR TITLE
Remove --pull always from Docker run to improve iteration speed

### DIFF
--- a/internal/controller/docker.go
+++ b/internal/controller/docker.go
@@ -41,10 +41,8 @@ func (c *Controller) runAgentContainer(ctx context.Context, params containerRunP
 	}
 
 	// Build Docker arguments
-	// Use --pull always to ensure we get the latest image, avoiding stale cached images
-	// that may be missing critical fixes (e.g., bun CLI symlink fix in PR #295)
 	args := []string{
-		"run", "--rm", "--pull", "always",
+		"run", "--rm",
 		"-v", fmt.Sprintf("%s:/workspace", c.workDir),
 		"-w", "/workspace",
 	}


### PR DESCRIPTION
## Summary
- Removes `--pull always` flag from Docker run arguments in `internal/controller/docker.go`
- This flag was forcing a Docker image pull check on every iteration, adding latency even when the image is already cached locally
- Addresses slowdowns observed in session `agentium-f66f7f03`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run a local session and verify Docker doesn't pull on every iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)