### PR TITLE
Fix signal detection by stripping markdown fences

### DIFF
--- a/internal/controller/complexity.go
+++ b/internal/controller/complexity.go
@@ -29,7 +29,13 @@ var complexityPattern = regexp.MustCompile(`(?m)^AGENTIUM_EVAL:[ \t]+(SIMPLE|COM
 // parseComplexityVerdict extracts the complexity verdict from agent output.
 // If no verdict line is found, defaults to COMPLEX (conservative fail-closed).
 func parseComplexityVerdict(output string) ComplexityResult {
+	// First try matching the raw output
 	matches := complexityPattern.FindStringSubmatch(output)
+	if matches == nil {
+		// Fallback: strip markdown fences and try again
+		cleaned := stripMarkdownFences(output)
+		matches = complexityPattern.FindStringSubmatch(cleaned)
+	}
 	if matches == nil {
 		return ComplexityResult{Verdict: ComplexityComplex, SignalFound: false}
 	}

--- a/internal/controller/complexity_test.go
+++ b/internal/controller/complexity_test.go
@@ -94,6 +94,28 @@ func TestParseComplexityVerdict(t *testing.T) {
 			wantFeedback: "",
 			wantSignal:   true,
 		},
+		// Markdown fence stripping tests
+		{
+			name:         "verdict inside markdown code fence is detected",
+			output:       "Here is my assessment:\n```\nAGENTIUM_EVAL: SIMPLE one file change\n```",
+			wantVerdict:  ComplexitySimple,
+			wantFeedback: "one file change",
+			wantSignal:   true,
+		},
+		{
+			name:         "verdict inside markdown fence with language tag",
+			output:       "```text\nAGENTIUM_EVAL: COMPLEX multiple components\n```",
+			wantVerdict:  ComplexityComplex,
+			wantFeedback: "multiple components",
+			wantSignal:   true,
+		},
+		{
+			name:         "raw verdict preferred over fenced verdict",
+			output:       "AGENTIUM_EVAL: SIMPLE quick fix\n```\nAGENTIUM_EVAL: COMPLEX should not match\n```",
+			wantVerdict:  ComplexitySimple,
+			wantFeedback: "quick fix",
+			wantSignal:   true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/judge_test.go
+++ b/internal/controller/judge_test.go
@@ -108,6 +108,35 @@ func TestParseJudgeVerdict(t *testing.T) {
 			wantFeedback: "real issue",
 			wantSignal:   true,
 		},
+		// Markdown fence stripping tests
+		{
+			name:         "verdict inside markdown code fence is detected",
+			output:       "Here is my verdict:\n```\nAGENTIUM_EVAL: ADVANCE\n```",
+			wantVerdict:  VerdictAdvance,
+			wantFeedback: "",
+			wantSignal:   true,
+		},
+		{
+			name:         "verdict inside markdown fence with language tag",
+			output:       "```text\nAGENTIUM_EVAL: ITERATE fix the tests\n```",
+			wantVerdict:  VerdictIterate,
+			wantFeedback: "fix the tests",
+			wantSignal:   true,
+		},
+		{
+			name:         "verdict inside triple backticks with surrounding text",
+			output:       "Analysis complete.\n```\nAGENTIUM_EVAL: BLOCKED need credentials\n```\nEnd of response.",
+			wantVerdict:  VerdictBlocked,
+			wantFeedback: "need credentials",
+			wantSignal:   true,
+		},
+		{
+			name:         "raw verdict preferred over fenced verdict",
+			output:       "AGENTIUM_EVAL: ADVANCE\n```\nAGENTIUM_EVAL: BLOCKED should not match\n```",
+			wantVerdict:  VerdictAdvance,
+			wantFeedback: "",
+			wantSignal:   true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/prompts/skills/status_signals.md
+++ b/prompts/skills/status_signals.md
@@ -107,6 +107,21 @@ Format: `AGENTIUM_EVAL: VERDICT [optional feedback]`
 - `AGENTIUM_EVAL: ITERATE <feedback>` - Phase needs another iteration with the given feedback
 - `AGENTIUM_EVAL: BLOCKED <reason>` - Cannot proceed without human intervention
 
+### Critical Formatting Rules
+
+**IMPORTANT:** Emit the verdict on its own line with NO surrounding markdown formatting.
+Do NOT wrap in code blocks or backticks. The signal must appear at the start of a line.
+
+Correct:
+```
+AGENTIUM_EVAL: ADVANCE
+```
+
+Wrong (will not be detected):
+- `` `AGENTIUM_EVAL: ADVANCE` `` - wrapped in backticks
+- Inside a markdown code fence with other content before it
+- `Here is my verdict: AGENTIUM_EVAL: ADVANCE` - not at line start
+
 ### Examples
 
 ```


### PR DESCRIPTION
## Summary

- Add fallback parsing in `judge.go` and `complexity.go` that strips markdown code fences before matching `AGENTIUM_EVAL` signals
- Strengthen prompt instructions in `status_signals.md` to warn against wrapping verdicts in code blocks
- Add test cases for markdown-wrapped signals

## Problem

Session `agentium-f66f7f03` terminated after 1 iteration with `BLOCKED` verdict due to `signal_found=false`. Investigation showed the agent likely emitted the verdict wrapped in a markdown code block, which the regex couldn't match because the pattern requires the signal at the start of a line.

## Solution

The signal parsers now:
1. First try matching the raw output (preserves existing behavior)
2. If no match, strip markdown fences and try again

This is fail-safe: raw signals still work, but wrapped signals are now also detected.

## Test plan

- [x] All existing tests pass
- [x] New test cases for markdown-wrapped signals pass
- [x] `go build ./...` succeeds

## Note

The `.agentium.yaml` file had an invalid `REVIEW:` phase entry (line 50-52) which is not tracked in git. This is a local config issue - users should remove it manually. Valid review phases are `PLAN_REVIEW`, `IMPLEMENT_REVIEW`, `DOCS_REVIEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)