### PR TITLE
Fix use_spot=false causing Terraform failures

### DIFF
--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -268,11 +268,11 @@ resource "google_compute_instance" "agentium" {
   }
 
   scheduling {
-    preemptible                 = var.use_spot
-    automatic_restart           = false
-    on_host_maintenance         = var.use_spot ? "TERMINATE" : "MIGRATE"
-    provisioning_model          = var.use_spot ? "SPOT" : "STANDARD"
-    instance_termination_action = var.use_spot ? "DELETE" : null
+    preemptible         = var.use_spot
+    automatic_restart   = !var.use_spot
+    on_host_maintenance = var.use_spot ? "TERMINATE" : "MIGRATE"
+    provisioning_model  = var.use_spot ? "SPOT" : "STANDARD"
+    # Removed instance_termination_action - only valid for SPOT, GCP defaults appropriately
 
     # Hard timeout at cloud level
     dynamic "max_run_duration" {


### PR DESCRIPTION
## Summary

- Fix Terraform scheduling block to properly handle non-spot VMs by removing `instance_termination_action` (only valid for SPOT) and setting `automatic_restart` correctly
- Capture and include Terraform stderr in error messages when provisioning fails

## Test plan

- [ ] Run `./agentium run` with `use_spot: false` in config
- [ ] Run `./agentium run` with `use_spot: true` in config  
- [ ] Run `./agentium run` with no `use_spot` setting (defaults to false)
- [ ] Verify Terraform error messages are now visible when provisioning fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)