### PR TITLE
Fix instance_termination_action required for max_run_duration

### DIFF
--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -268,11 +268,11 @@ resource "google_compute_instance" "agentium" {
   }
 
   scheduling {
-    preemptible         = var.use_spot
-    automatic_restart   = !var.use_spot
-    on_host_maintenance = var.use_spot ? "TERMINATE" : "MIGRATE"
-    provisioning_model  = var.use_spot ? "SPOT" : "STANDARD"
-    # Removed instance_termination_action - only valid for SPOT, GCP defaults appropriately
+    preemptible                 = var.use_spot
+    automatic_restart           = !var.use_spot
+    on_host_maintenance         = var.use_spot ? "TERMINATE" : "MIGRATE"
+    provisioning_model          = var.use_spot ? "SPOT" : "STANDARD"
+    instance_termination_action = (var.use_spot || var.max_run_duration != "") ? "DELETE" : null
 
     # Hard timeout at cloud level
     dynamic "max_run_duration" {


### PR DESCRIPTION
## Summary

- GCP requires `instance_termination_action` when using `max_run_duration`, even for standard VMs
- Now set to "DELETE" when either `use_spot=true` OR `max_run_duration` is configured

## Test plan

- [ ] Run with `use_spot: false` and `max_run_duration` set
- [ ] Run with `use_spot: true`
- [ ] Run with `use_spot: false` and no `max_run_duration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)