### PR TITLE
Add documentation for monorepo support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,6 +120,29 @@ After each phase (except PR_CREATION), an LLM evaluator assesses the output:
 
 Every phase iteration and evaluator verdict is posted as a comment on the GitHub issue.
 
+### Monorepo Scope Enforcement
+
+For pnpm workspace monorepos, Agentium enforces per-package scope:
+
+**Package Identification:**
+- Issues must have a `pkg:<name>` label (e.g., `pkg:core`, `pkg:web`)
+- The label maps to a package directory in `pnpm-workspace.yaml`
+- Sessions without a package label are rejected in monorepo mode
+
+**Scope Validation:**
+- After each iteration, the controller validates file changes
+- Only files within the target package directory are allowed
+- Allowed exceptions: `package.json`, `pnpm-lock.yaml`, `.github/workflows/`
+- Out-of-scope changes trigger:
+  1. Automatic `git checkout .` and `git clean -fd` to reset changes
+  2. Iteration marked as failed with scope violation feedback
+  3. Agent continues with feedback about the violation
+
+**Hierarchical Instructions:**
+- Root `.agentium/AGENT.md` provides repository-wide instructions
+- Package `.agentium/AGENT.md` provides package-specific instructions
+- Both are merged and injected into the agent prompt
+
 ### VM Termination Conditions
 
 The VM **must self-terminate** when **any** of the following conditions occur:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Agentium implements the [Ralph Wiggum loop](https://github.com/ghuntley/how-to-r
 - 🔐 **PR-Only Output** — Agents create pull requests for human review (no production access)
 - 🚀 **Concurrent Sessions** — Launch multiple sessions in parallel on separate VMs
 - 🤖 **Multi-Agent Support** — Claude Code and Aider (more coming soon)
+- 📦 **Monorepo Support** — Per-package scope enforcement for pnpm workspaces
 - 💾 **Memory System** — Context persistence between phase iterations
 - 🎯 **Model Routing** — Assign different models to different phases
 - 🏗️ **Language Auto-Detection** — Automatically installs required runtimes

--- a/docs/AGENT.template.md
+++ b/docs/AGENT.template.md
@@ -87,3 +87,50 @@ List files or directories the agent should not modify:
 ## Contact
 
 If the agent encounters issues outside its scope, it should note them in the PR description for human follow-up.
+
+---
+
+# Package-Specific Instructions (Monorepos)
+
+For pnpm workspace monorepos, you can create package-specific AGENT.md files. Place them at `<package-path>/.agentium/AGENT.md` and they will be merged with the root instructions when the agent targets that package.
+
+**Example structure:**
+
+```
+my-monorepo/
+├── .agentium/AGENT.md          # Root instructions (applies to all packages)
+├── packages/
+│   ├── core/
+│   │   └── .agentium/AGENT.md  # Core-specific instructions
+│   └── web/
+│       └── .agentium/AGENT.md  # Web-specific instructions
+└── pnpm-workspace.yaml
+```
+
+**Example package AGENT.md (`packages/web/.agentium/AGENT.md`):**
+
+```markdown
+# Web Package Instructions
+
+## Build & Test Commands
+
+```bash
+pnpm --filter web build
+pnpm --filter web test
+pnpm --filter web lint
+```
+
+## Framework Notes
+
+- This package uses React with TypeScript
+- State management via Zustand
+- Styling with Tailwind CSS
+
+## Testing Requirements
+
+- Use React Testing Library for component tests
+- Mock API calls with MSW
+- Snapshot tests for complex UI components
+```
+
+The agent will see both root and package instructions, clearly separated.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Welcome to the Agentium documentation. This directory contains comprehensive gui
 
 | Guide | Description |
 |-------|-------------|
-| [Getting Started](getting-started.md) | Installation, prerequisites, and quickstart tutorial |
+| [Getting Started](getting-started.md) | Installation, prerequisites, quickstart, and monorepo setup |
 | [Configuration Reference](configuration.md) | Full `.agentium.yaml` reference with all options |
 | [CLI Reference](cli-reference.md) | All commands, flags, and usage examples |
 | [Cloud Setup Guides](cloud-setup/) | Provider-specific setup instructions |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -70,6 +70,15 @@ agentium init --repo github.com/myorg/myrepo --force
 
 Creates `.agentium.yaml` with the specified configuration. Also generates `.agentium/AGENT.md` with auto-detected project information (build commands, test commands, project structure) unless `--skip-agent-md` is specified. If a config file already exists and `--force` is not set, the command will exit with an error.
 
+**Monorepo Detection:**
+
+If a `pnpm-workspace.yaml` file is present, `agentium init` automatically:
+- Sets `monorepo.enabled: true` in the config
+- Sets `monorepo.label_prefix: "pkg"` as the default prefix
+- Outputs: `Detected pnpm-workspace.yaml - monorepo support enabled`
+
+This enables per-package scope enforcement, requiring issues to have `pkg:<package-name>` labels.
+
 ---
 
 ### `agentium refresh`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,11 @@ delegation:
       skills:
         - "code_review"
         - "lint_detection"
+
+# Monorepo support (auto-detected for pnpm workspaces)
+monorepo:
+  enabled: true                     # Enable package scope enforcement
+  label_prefix: "pkg"               # Prefix for package labels (pkg:core, pkg:web)
 ```
 
 ## Configuration Sections
@@ -231,6 +236,36 @@ After each phase, the evaluator produces a verdict:
 - **BLOCKED** — Stop and signal human intervention needed
 
 Evaluator feedback from ITERATE verdicts is stored in the memory system and provided as context in the next iteration of that phase.
+
+### monorepo
+
+Configuration for pnpm workspace monorepo support. Automatically set by `agentium init` when `pnpm-workspace.yaml` is detected.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `enabled` | bool | No | `false` | Enable monorepo mode with package scope enforcement |
+| `label_prefix` | string | No | `pkg` | Prefix for package labels (e.g., `pkg:core`, `pkg:web`) |
+
+**Monorepo behavior:**
+
+When `monorepo.enabled` is `true`:
+- Issues must have a `<prefix>:<package-name>` label to specify the target package
+- The agent can only modify files within the target package directory
+- Out-of-scope file changes are automatically reset and block the iteration
+- Allowed exceptions: root `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.github/workflows/`
+- Hierarchical AGENT.md loading: root + package-specific instructions are merged
+
+**Example:**
+
+```yaml
+monorepo:
+  enabled: true
+  label_prefix: "pkg"  # Issues need labels like pkg:core, pkg:api
+```
+
+**Package-specific agent instructions:**
+
+Create `.agentium/AGENT.md` within a package directory to provide package-specific instructions. These are merged with the root AGENT.md when the agent targets that package.
 
 ### delegation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -188,6 +188,53 @@ agentium run --repo github.com/org/repo --issues 42 \
 agentium run --repo github.com/org/repo --issues 42 --dry-run
 ```
 
+### Working with Monorepos (pnpm Workspaces)
+
+For projects using pnpm workspaces, Agentium provides per-package scope enforcement:
+
+```bash
+# Agentium auto-detects pnpm-workspace.yaml during init
+agentium init --repo github.com/org/monorepo --provider gcp
+# Output: Detected pnpm-workspace.yaml - monorepo support enabled
+```
+
+When monorepo mode is enabled:
+- Issues **must** have a `pkg:<package-name>` label to specify scope
+- Agents can only modify files within the target package directory
+- Out-of-scope file changes are automatically reset and block iteration
+- Root-level files (`package.json`, `pnpm-lock.yaml`, `.github/workflows/`) are allowed
+
+**Creating package-scoped issues:**
+
+Use the `/gh-issues` skill which automatically handles package labels:
+
+```bash
+# The skill will prompt for package selection in monorepos
+/gh-issues Add validation to the form component
+```
+
+Or create issues manually with the required label:
+
+```bash
+gh label create "pkg:web" --color "0052CC"
+gh issue create --title "Add form validation" --label "pkg:web,enhancement"
+```
+
+**Package-specific AGENT.md:**
+
+You can provide per-package agent instructions by creating `.agentium/AGENT.md` within a package directory. These are merged with the root AGENT.md:
+
+```
+my-monorepo/
+├── .agentium/AGENT.md          # Repository-wide instructions
+├── packages/
+│   ├── core/
+│   │   └── .agentium/AGENT.md  # Core package instructions
+│   └── web/
+│       └── .agentium/AGENT.md  # Web package instructions
+└── pnpm-workspace.yaml
+```
+
 ### Local Interactive Mode (Debugging)
 
 Run the controller locally without provisioning a VM. The agent runs in interactive mode, prompting for permission approvals:


### PR DESCRIPTION
## Summary

- Document pnpm workspace monorepo features added in PR #309
- Add monorepo setup section to getting-started guide
- Document `monorepo` configuration section with all options
- Update CLI reference with monorepo detection behavior
- Add monorepo scope enforcement to architecture docs
- Include package-specific AGENT.md examples and templates

## Changes

**README.md**
- Added monorepo support to key features list

**docs/getting-started.md**
- New "Working with Monorepos" section covering:
  - Auto-detection during init
  - Package label requirements
  - Creating package-scoped issues
  - Package-specific AGENT.md files

**docs/configuration.md**
- New `monorepo` section documenting:
  - `enabled` and `label_prefix` fields
  - Scope enforcement behavior
  - Allowed file exceptions
  - Hierarchical AGENT.md loading

**docs/cli-reference.md**
- Added "Monorepo Detection" section to `agentium init`

**ARCHITECTURE.md**
- New "Monorepo Scope Enforcement" section covering:
  - Package identification via labels
  - Scope validation behavior
  - Hierarchical instructions

**docs/AGENT.template.md**
- Added package-specific AGENT.md section with:
  - Directory structure example
  - Sample package AGENT.md content

## Test plan

- [x] Verified build passes (`go build ./...`)
- [x] Verified tests pass (`go test ./...`)
- [ ] Manual review of documentation accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)