### PR TITLE
Disable Claude Code sandbox in container for test runners

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -51,6 +51,11 @@ RUN echo "agentium ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
     mkdir -p /home/agentium/.claude && chown agentium:agentium /home/agentium/.claude
 
+# Disable Claude Code bash sandbox to allow test runners (vitest, jest, etc.)
+# Safe in ephemeral VM containers; use your own judgment for custom deployments
+RUN echo '{"bashSandboxMode": "off"}' > /home/agentium/.claude/settings.json && \
+    chown agentium:agentium /home/agentium/.claude/settings.json
+
 # Copy runtime installation scripts
 COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh
 COPY docker/scripts/agent-wrapper.sh /runtime-scripts/agent-wrapper.sh

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -344,6 +344,20 @@ Look for:
 - Missing `ANTHROPIC_API_KEY` - Claude API key not provided (when using `api` auth mode)
 - Container exit codes (non-zero indicates failure)
 
+### Test runners fail with "sandbox restrictions"
+
+**Cause:** Claude Code's bash sandbox blocks test runners like vitest, jest, or pytest that spawn child processes.
+
+**Fix:** The official Agentium container images have the sandbox disabled by default (safe because VMs are ephemeral and isolated). If you're using a custom image, add this to your Dockerfile:
+
+```dockerfile
+# Disable Claude Code sandbox (not needed in ephemeral VM container)
+RUN echo '{"bashSandboxMode": "off"}' > /home/agentium/.claude/settings.json && \
+    chown agentium:agentium /home/agentium/.claude/settings.json
+```
+
+**Why this is safe:** Agentium VMs are ephemeral (self-destruct after session), isolated (no access beyond the cloned repo), and containerized. The sandbox is designed to protect long-running developer machines and is deemed sufficiently safe in this environment to be worth the benefits. Use your own judgment.
+
 ### "Image not found" errors
 
 **Cause:** Container image doesn't exist or isn't accessible.


### PR DESCRIPTION
## Summary

- Disables Claude Code's bash sandbox in the container image to allow test runners (vitest, jest, pytest) that spawn child processes
- Documents the sandbox configuration in the troubleshooting guide

## Context

Test runners fail with "sandbox restrictions" errors because Claude Code sandboxes bash commands by default. Since Agentium VMs are ephemeral, isolated, and containerized, disabling the sandbox is deemed sufficiently safe to be worth the benefits.

## Test plan

- [ ] Rebuild container image with the new settings
- [ ] Run an Agentium session on a project with vitest tests
- [ ] Verify tests execute without sandbox errors

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)