### PR TITLE
Embed terraform files in agentium binary

### DIFF
--- a/terraform/embed.go
+++ b/terraform/embed.go
@@ -1,0 +1,51 @@
+package terraform
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+//go:embed modules/vm/gcp/*.tf
+var gcpVMFiles embed.FS
+
+const (
+	ProviderGCP   = "gcp"
+	ProviderAWS   = "aws"
+	ProviderAzure = "azure"
+)
+
+// GetVMFiles returns the embedded terraform files for the provider.
+func GetVMFiles(provider string) (fs.FS, error) {
+	switch provider {
+	case ProviderGCP:
+		return fs.Sub(gcpVMFiles, "modules/vm/gcp")
+	case ProviderAWS:
+		return nil, fmt.Errorf("AWS terraform modules not yet implemented")
+	case ProviderAzure:
+		return nil, fmt.Errorf("Azure terraform modules not yet implemented")
+	default:
+		return nil, fmt.Errorf("unknown provider: %s", provider)
+	}
+}
+
+// WriteVMFiles writes terraform files for the provider to destDir.
+func WriteVMFiles(provider string, destDir string) error {
+	fsys, err := GetVMFiles(provider)
+	if err != nil {
+		return err
+	}
+
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".tf" {
+			return err
+		}
+		content, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
+		}
+		return os.WriteFile(filepath.Join(destDir, filepath.Base(path)), content, 0644)
+	})
+}

--- a/terraform/embed_test.go
+++ b/terraform/embed_test.go
@@ -1,0 +1,113 @@
+package terraform
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetVMFiles_GCP(t *testing.T) {
+	fsys, err := GetVMFiles(ProviderGCP)
+	if err != nil {
+		t.Fatalf("GetVMFiles(GCP) returned error: %v", err)
+	}
+	if fsys == nil {
+		t.Fatal("GetVMFiles(GCP) returned nil filesystem")
+	}
+
+	// Verify main.tf exists
+	_, err = fs.Stat(fsys, "main.tf")
+	if err != nil {
+		t.Errorf("main.tf not found in embedded files: %v", err)
+	}
+
+	// Verify versions.tf exists
+	_, err = fs.Stat(fsys, "versions.tf")
+	if err != nil {
+		t.Errorf("versions.tf not found in embedded files: %v", err)
+	}
+}
+
+func TestGetVMFiles_AWS(t *testing.T) {
+	_, err := GetVMFiles(ProviderAWS)
+	if err == nil {
+		t.Error("GetVMFiles(AWS) should return error (not yet implemented)")
+	}
+}
+
+func TestGetVMFiles_Azure(t *testing.T) {
+	_, err := GetVMFiles(ProviderAzure)
+	if err == nil {
+		t.Error("GetVMFiles(Azure) should return error (not yet implemented)")
+	}
+}
+
+func TestGetVMFiles_UnknownProvider(t *testing.T) {
+	_, err := GetVMFiles("unknown")
+	if err == nil {
+		t.Error("GetVMFiles(unknown) should return error")
+	}
+}
+
+func TestWriteVMFiles_GCP(t *testing.T) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "terraform-embed-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Write files
+	err = WriteVMFiles(ProviderGCP, tempDir)
+	if err != nil {
+		t.Fatalf("WriteVMFiles(GCP) returned error: %v", err)
+	}
+
+	// Verify main.tf was created
+	mainTfPath := filepath.Join(tempDir, "main.tf")
+	info, err := os.Stat(mainTfPath)
+	if err != nil {
+		t.Errorf("main.tf not created: %v", err)
+	} else {
+		// Verify permissions are 0644
+		mode := info.Mode().Perm()
+		if mode != 0644 {
+			t.Errorf("main.tf has wrong permissions: got %o, want 0644", mode)
+		}
+	}
+
+	// Verify versions.tf was created
+	versionsTfPath := filepath.Join(tempDir, "versions.tf")
+	info, err = os.Stat(versionsTfPath)
+	if err != nil {
+		t.Errorf("versions.tf not created: %v", err)
+	} else {
+		// Verify permissions are 0644
+		mode := info.Mode().Perm()
+		if mode != 0644 {
+			t.Errorf("versions.tf has wrong permissions: got %o, want 0644", mode)
+		}
+	}
+
+	// Verify content is not empty
+	content, err := os.ReadFile(mainTfPath)
+	if err != nil {
+		t.Errorf("Failed to read main.tf: %v", err)
+	} else if len(content) == 0 {
+		t.Error("main.tf is empty")
+	}
+}
+
+func TestWriteVMFiles_InvalidProvider(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "terraform-embed-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = WriteVMFiles("invalid", tempDir)
+	if err == nil {
+		t.Error("WriteVMFiles(invalid) should return error")
+	}
+}


### PR DESCRIPTION
## Summary
- Use Go's `embed` package to include terraform modules directly in the binary
- Eliminate runtime filesystem lookups that fail when binary is symlinked
- Simplify `GCPProvisioner` by removing path-finding logic

## Changes
- New `terraform/embed.go` with `GetVMFiles()` and `WriteVMFiles()` functions
- New `terraform/embed_test.go` with comprehensive tests
- Modified `internal/provisioner/gcp.go` to use embedded files

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go test -v ./terraform/...` verifies embedded files are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)