### PR TITLE
Fix linting errors from PR #317

### DIFF
--- a/terraform/embed.go
+++ b/terraform/embed.go
@@ -25,7 +25,7 @@ func GetVMFiles(provider string) (fs.FS, error) {
 	case ProviderAWS:
 		return nil, fmt.Errorf("AWS terraform modules not yet implemented")
 	case ProviderAzure:
-		return nil, fmt.Errorf("Azure terraform modules not yet implemented")
+		return nil, fmt.Errorf("azure terraform modules not yet implemented")
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", provider)
 	}

--- a/terraform/embed_test.go
+++ b/terraform/embed_test.go
@@ -56,7 +56,7 @@ func TestWriteVMFiles_GCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Write files
 	err = WriteVMFiles(ProviderGCP, tempDir)
@@ -104,7 +104,7 @@ func TestWriteVMFiles_InvalidProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	err = WriteVMFiles("invalid", tempDir)
 	if err == nil {


### PR DESCRIPTION
## Summary
- Lowercase error string for Azure provider (staticcheck ST1005)
- Handle `os.RemoveAll` return value in test cleanup (errcheck)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./terraform/...` passes
- [x] `golangci-lint run ./terraform/...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)