### PR TITLE
Fix Claude Code sandbox settings format for containers

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -51,9 +51,11 @@ RUN echo "agentium ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
     mkdir -p /home/agentium/.claude && chown agentium:agentium /home/agentium/.claude
 
-# Disable Claude Code bash sandbox to allow test runners (vitest, jest, etc.)
+# Configure Claude Code for container environment
+# - sandbox.enabled=false: Explicitly disable sandbox (default, but be explicit)
+# - enableWeakerNestedSandbox=true: Required for unprivileged Docker containers
 # Safe in ephemeral VM containers; use your own judgment for custom deployments
-RUN echo '{"bashSandboxMode": "off"}' > /home/agentium/.claude/settings.json && \
+RUN echo '{"sandbox":{"enabled":false,"enableWeakerNestedSandbox":true}}' > /home/agentium/.claude/settings.json && \
     chown agentium:agentium /home/agentium/.claude/settings.json
 
 # Copy runtime installation scripts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -346,13 +346,15 @@ Look for:
 
 ### Test runners fail with "sandbox restrictions"
 
-**Cause:** Claude Code's bash sandbox blocks test runners like vitest, jest, or pytest that spawn child processes.
+**Cause:** Claude Code's sandbox blocks test runners like vitest, jest, or pytest that spawn child processes or load native modules (like rollup's native bindings).
 
-**Fix:** The official Agentium container images have the sandbox disabled by default (safe because VMs are ephemeral and isolated). If you're using a custom image, add this to your Dockerfile:
+**Fix:** The official Agentium container images are configured for container environments by default. If you're using a custom image, add this to your Dockerfile:
 
 ```dockerfile
-# Disable Claude Code sandbox (not needed in ephemeral VM container)
-RUN echo '{"bashSandboxMode": "off"}' > /home/agentium/.claude/settings.json && \
+# Configure Claude Code for container environment
+# - sandbox.enabled=false: Explicitly disable sandbox
+# - enableWeakerNestedSandbox=true: Required for unprivileged Docker containers
+RUN echo '{"sandbox":{"enabled":false,"enableWeakerNestedSandbox":true}}' > /home/agentium/.claude/settings.json && \
     chown agentium:agentium /home/agentium/.claude/settings.json
 ```
 


### PR DESCRIPTION
## Summary

- Fix incorrect sandbox settings key (`bashSandboxMode` → `sandbox.enabled`)
- Add `enableWeakerNestedSandbox: true` for unprivileged Docker containers
- Update troubleshooting docs with correct configuration

This fixes test runners (vitest, jest, pytest) failing with "sandbox native module restrictions" errors when loading native bindings like rollup.

## Test plan

- [ ] Docker image builds successfully
- [ ] Test runners work in container environment (vitest with rollup native modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)