### PR TITLE
Test: Enable Claude Code sandbox with forks pool compatibility

### DIFF
--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -51,9 +51,11 @@ RUN echo "agentium ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
     mkdir -p /home/agentium/.claude && chown agentium:agentium /home/agentium/.claude
 
-# Disable Claude Code bash sandbox to allow test runners (vitest, jest, etc.)
-# Safe in ephemeral VM containers; use your own judgment for custom deployments
-RUN echo '{"bashSandboxMode": "off"}' > /home/agentium/.claude/settings.json && \
+# Configure Claude Code sandbox for container environment
+# - sandbox.enabled=true: Keep sandbox active for security
+# - enableWeakerNestedSandbox=true: Required for unprivileged Docker containers
+# Note: Test frameworks must use forks pool (vitest: pool: 'forks') for compatibility
+RUN echo '{"sandbox":{"enabled":true,"enableWeakerNestedSandbox":true}}' > /home/agentium/.claude/settings.json && \
     chown agentium:agentium /home/agentium/.claude/settings.json
 
 # Copy runtime installation scripts


### PR DESCRIPTION
## Summary

This test branch enables the Claude Code sandbox instead of disabling it:
- `sandbox.enabled: true` - Keep sandbox active for prompt injection protection
- `enableWeakerNestedSandbox: true` - Required for unprivileged Docker containers

## Testing

Test this branch together with [stillway PR #25](https://github.com/andymwolf/stillway/pull/25), which adds the vitest forks pool configuration.

### Test Commands

Build and run an Agentium session:
```bash
# Build from this branch
go build -o agentium ./cmd/agentium

# Run on stillway with the test branch
./agentium run --repo andymwolf/stillway --branch test/vitest-sandbox-compatible \
  --prompt "Run the mcp-server tests with: pnpm --filter @stillway/mcp-server test"
```

### Expected Outcome

If vitest with `pool: 'forks'` works in the sandbox:
- Tests pass without "sandbox native module restrictions" error
- We can keep sandbox enabled for better security

### Security Trade-offs

| Configuration | Security | Compatibility |
|---------------|----------|---------------|
| Sandbox OFF (current main) | Lower | Any test framework |
| Sandbox ON + forks pool | Higher | Requires forks pool config |

🤖 Generated with [Claude Code](https://claude.com/claude-code)