### PR TITLE
Add phase-specific reasoning levels for Codex agent

### DIFF
--- a/internal/agent/codex/adapter.go
+++ b/internal/agent/codex/adapter.go
@@ -91,6 +91,11 @@ func (a *Adapter) BuildCommand(session *agent.Session, iteration int) []string {
 		args = append(args, "--model", model)
 	}
 
+	// Reasoning level override (Codex-specific)
+	if session.IterationContext != nil && session.IterationContext.ReasoningOverride != "" {
+		args = append(args, "--reasoning", session.IterationContext.ReasoningOverride)
+	}
+
 	// Build developer instructions from system/project prompts + status signal instructions.
 	// Escape newlines so the value survives CLI config parsing as a single argument.
 	developerInstructions := a.buildDeveloperInstructions(session)

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -10,13 +10,14 @@ type ExistingWork struct {
 // IterationContext provides phase-aware context for a single iteration.
 // When non-nil, SkillsPrompt should be preferred over Session.SystemPrompt.
 type IterationContext struct {
-	Phase         string // e.g., "IMPLEMENT", "TEST"
-	SkillsPrompt  string // Composed from phase-relevant skills
-	MemoryContext string // Summarized memory from previous iterations (legacy mode)
-	PhaseInput    string // Structured handoff input for this phase (handoff mode)
-	ModelOverride string // Model ID to pass as --model flag to the agent CLI
-	Iteration     int    // Current iteration number
-	SubTaskID     string // Unique ID for delegation tracking
+	Phase             string // e.g., "IMPLEMENT", "TEST"
+	SkillsPrompt      string // Composed from phase-relevant skills
+	MemoryContext     string // Summarized memory from previous iterations (legacy mode)
+	PhaseInput        string // Structured handoff input for this phase (handoff mode)
+	ModelOverride     string // Model ID to pass as --model flag to the agent CLI
+	ReasoningOverride string // Reasoning level to pass as --reasoning flag (for agents that support it)
+	Iteration         int    // Current iteration number
+	SubTaskID         string // Unique ID for delegation tracking
 }
 
 // Session represents an agent session with all necessary context

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1807,6 +1807,9 @@ func (c *Controller) runIteration(ctx context.Context) (*agent.IterationResult, 
 		if modelCfg.Model != "" {
 			session.IterationContext.ModelOverride = modelCfg.Model
 		}
+		if modelCfg.Reasoning != "" {
+			session.IterationContext.ReasoningOverride = modelCfg.Reasoning
+		}
 		c.logInfo("Routing phase %s: adapter=%s model=%s", phase, activeAgent.Name(), modelCfg.Model)
 	}
 

--- a/internal/controller/judge.go
+++ b/internal/controller/judge.go
@@ -138,6 +138,12 @@ func (c *Controller) runJudge(ctx context.Context, params judgeRunParams) (Judge
 			}
 			session.IterationContext.ModelOverride = modelCfg.Model
 		}
+		if modelCfg.Reasoning != "" {
+			if session.IterationContext == nil {
+				session.IterationContext = &agent.IterationContext{}
+			}
+			session.IterationContext.ReasoningOverride = modelCfg.Reasoning
+		}
 	}
 
 	env := activeAgent.BuildEnv(session, 0)

--- a/internal/controller/reviewer.go
+++ b/internal/controller/reviewer.go
@@ -80,6 +80,12 @@ func (c *Controller) runReviewer(ctx context.Context, params reviewRunParams) (R
 			}
 			session.IterationContext.ModelOverride = modelCfg.Model
 		}
+		if modelCfg.Reasoning != "" {
+			if session.IterationContext == nil {
+				session.IterationContext = &agent.IterationContext{}
+			}
+			session.IterationContext.ReasoningOverride = modelCfg.Reasoning
+		}
 	}
 
 	env := activeAgent.BuildEnv(session, 0)

--- a/internal/routing/types.go
+++ b/internal/routing/types.go
@@ -7,8 +7,26 @@ import (
 
 // ModelConfig specifies an adapter and model for a phase
 type ModelConfig struct {
-	Adapter string `json:"adapter" yaml:"adapter" mapstructure:"adapter"`
-	Model   string `json:"model" yaml:"model" mapstructure:"model"`
+	Adapter   string `json:"adapter" yaml:"adapter" mapstructure:"adapter"`
+	Model     string `json:"model" yaml:"model" mapstructure:"model"`
+	Reasoning string `json:"reasoning,omitempty" yaml:"reasoning,omitempty" mapstructure:"reasoning"`
+}
+
+// ValidReasoningLevels is the set of recognized reasoning level values.
+var ValidReasoningLevels = map[string]bool{
+	"low":    true,
+	"medium": true,
+	"high":   true,
+}
+
+// ValidReasoningLevelNames returns the sorted list of recognized reasoning levels.
+func ValidReasoningLevelNames() []string {
+	names := make([]string, 0, len(ValidReasoningLevels))
+	for level := range ValidReasoningLevels {
+		names = append(names, level)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // PhaseRouting maps phases to adapter+model configurations


### PR DESCRIPTION
## Summary

- Adds a `reasoning` field to the routing configuration that allows per-phase reasoning levels for the Codex agent
- The field uses semantic values ("low", "medium", "high") that the Codex adapter translates to `--reasoning` CLI flags
- Other adapters gracefully ignore this field (backward compatible)

### Configuration Example

```yaml
routing:
  default:
    adapter: "codex"
    model: "o3"
  overrides:
    PLAN_REVIEW:
      adapter: "codex"
      model: "o3"
      reasoning: "medium"
    IMPLEMENT_REVIEW:
      adapter: "codex"
      model: "o3"
      reasoning: "high"
```

### Changes

- `internal/routing/types.go`: Add `Reasoning` field to `ModelConfig` struct, `ValidReasoningLevels` map, and helper
- `internal/agent/interface.go`: Add `ReasoningOverride` field to `IterationContext` struct
- `internal/agent/codex/adapter.go`: Add `--reasoning` flag when `ReasoningOverride` is set
- `internal/controller/controller.go`: Propagate reasoning from routing config
- `internal/controller/reviewer.go`: Propagate reasoning from routing config
- `internal/controller/judge.go`: Propagate reasoning from routing config

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./internal/routing/...` - all 26 tests pass
- [x] `go test ./internal/agent/codex/...` - all 49 tests pass  
- [x] `go test ./...` - all project tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)