### PR TITLE
Fix unparam lint error in prePullAgentImages

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -538,10 +538,7 @@ func (c *Controller) initSession(ctx context.Context) error {
 	}
 
 	// Pre-pull agent container images to avoid first-iteration latency
-	if err := c.prePullAgentImages(ctx); err != nil {
-		c.logWarning("Failed to pre-pull agent images: %v", err)
-		// Non-fatal: images will be pulled on first use
-	}
+	c.prePullAgentImages(ctx)
 
 	// Clone repository (skip if cloning inside container)
 	if !c.config.CloneInsideContainer {

--- a/internal/controller/docker.go
+++ b/internal/controller/docker.go
@@ -215,7 +215,8 @@ func (c *Controller) executeAndCollect(cmd *exec.Cmd, logTag string) (stdoutByte
 
 // prePullAgentImages pulls all agent container images that will be used in this session.
 // This is called during initSession() to avoid pull latency on the first iteration.
-func (c *Controller) prePullAgentImages(ctx context.Context) error {
+// Failures are logged as warnings but not returned since pre-pulling is non-fatal.
+func (c *Controller) prePullAgentImages(ctx context.Context) {
 	// Collect unique images from all configured adapters
 	images := make(map[string]bool)
 	for _, adapter := range c.adapters {
@@ -223,7 +224,7 @@ func (c *Controller) prePullAgentImages(ctx context.Context) error {
 	}
 
 	if len(images) == 0 {
-		return nil
+		return
 	}
 
 	c.logInfo("Pre-pulling %d agent container image(s)...", len(images))
@@ -254,8 +255,6 @@ func (c *Controller) prePullAgentImages(ctx context.Context) error {
 			c.logInfo("Successfully pulled: %s", image)
 		}
 	}
-
-	return nil
 }
 
 // logAgentEvents logs structured agent events at DEBUG level to Cloud Logging.


### PR DESCRIPTION
## Summary
- Remove unused error return from `prePullAgentImages()` since it always returns `nil`
- The function handles errors internally as warnings (non-fatal pre-pull)
- Fixes the `unparam` linter error that's failing CI on main

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes
- [x] `golangci-lint run ./internal/controller/...` shows 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)