### PR TITLE
Fix codex binary name in tarball extraction

### DIFF
--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -36,7 +36,7 @@ RUN CODEX_VERSION=$(curl -s https://api.github.com/repos/openai/codex/releases/l
     echo "Installing Codex CLI ${CODEX_VERSION}..." && \
     curl -fsSL "https://github.com/openai/codex/releases/download/${CODEX_VERSION}/codex-x86_64-unknown-linux-musl.tar.gz" -o /tmp/codex.tar.gz && \
     tar -xzf /tmp/codex.tar.gz -C /tmp && \
-    mv /tmp/codex /usr/local/bin/codex && \
+    mv /tmp/codex-x86_64-unknown-linux-musl /usr/local/bin/codex && \
     chmod +x /usr/local/bin/codex && \
     rm /tmp/codex.tar.gz && \
     codex --version


### PR DESCRIPTION
## Summary
- The binary inside the GitHub release tarball is named `codex-x86_64-unknown-linux-musl`, not just `codex`
- Updated the mv command to use the correct filename

## Test plan
- [ ] Rebuild codex Docker image
- [ ] Verify codex --version works during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)