### PR TITLE
Remove auth validation that blocks workspace fallback

### DIFF
--- a/internal/controller/docker.go
+++ b/internal/controller/docker.go
@@ -90,25 +90,9 @@ func (c *Controller) runAgentContainer(ctx context.Context, params containerRunP
 		}
 	}
 
-	// Validate auth files exist in cloud mode before mounting
-	// This prevents Docker from creating directories at mount points when files are missing
-	// Only validate auth for the specific adapter being run to avoid false failures
-	if !c.config.Interactive {
-		switch params.Agent.Name() {
-		case "claude-code":
-			if c.config.ClaudeAuth.AuthMode == "oauth" {
-				if err := c.validateAuthFile("/etc/agentium/claude-auth.json", "Claude"); err != nil {
-					return nil, err
-				}
-			}
-		case "codex":
-			if c.config.CodexAuth.AuthJSONBase64 != "" {
-				if err := c.validateAuthFile("/etc/agentium/codex-auth.json", "Codex"); err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
+	// Note: Auth file validation removed - we now use workspace fallback when
+	// /etc/agentium files are missing or corrupted (see mount logic below).
+	// This handles cloud-init timing issues and Docker directory creation gracefully.
 
 	// Build Docker arguments
 	args := []string{


### PR DESCRIPTION
## Summary

Follow-up fix to PR #361. The previous fix added workspace fallback for auth files, but the `validateAuthFile` call still returned an error before reaching the fallback logic.

## Problem

```
[16:57:21] Removing stale directory at auth path: /etc/agentium/codex-auth.json
[16:57:21] Codex auth path cleanup failed due to read-only filesystem: /etc/agentium/codex-auth.json
[16:57:21] Reviewer container failed for phase IMPLEMENT: Codex auth path is a directory - Docker mount failed
```

The validation block was still running and returning an error, so we never reached the workspace fallback code.

## Fix

Remove the validation block since the fallback mechanism now handles missing/invalid auth files gracefully in the mount logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)