### PR TITLE
Add semantic versioning with build-time injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
         run: |
           ext=""
           if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
-          go build -o agentium-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/agentium
+          LDFLAGS="-X github.com/andywolf/agentium/internal/version.Commit=${{ github.sha }}"
+          go build -ldflags="${LDFLAGS}" -o agentium-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/agentium
 
       - name: Build controller
         env:
@@ -77,4 +78,5 @@ jobs:
         run: |
           ext=""
           if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
-          go build -o controller-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/controller
+          LDFLAGS="-X github.com/andywolf/agentium/internal/version.Commit=${{ github.sha }}"
+          go build -ldflags="${LDFLAGS}" -o controller-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/controller

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=dev
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -98,5 +102,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=dev
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,18 @@ jobs:
           ext=""
           if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
           mkdir -p dist
-          go build -ldflags="-s -w -X main.version=${{ github.ref_name }}" \
+
+          VERSION="${{ github.ref_name }}"
+          COMMIT="${{ github.sha }}"
+          BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          LDFLAGS="-s -w \
+            -X github.com/andywolf/agentium/internal/version.Version=${VERSION} \
+            -X github.com/andywolf/agentium/internal/version.Commit=${COMMIT} \
+            -X github.com/andywolf/agentium/internal/version.BuildDate=${BUILD_DATE}"
+
+          go build -ldflags="${LDFLAGS}" \
             -o dist/agentium-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/agentium
-          go build -ldflags="-s -w -X main.version=${{ github.ref_name }}" \
+          go build -ldflags="${LDFLAGS}" \
             -o dist/controller-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/controller
 
       - name: Upload artifacts
@@ -125,5 +134,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docker/aider/Dockerfile
+++ b/docker/aider/Dockerfile
@@ -3,6 +3,19 @@
 
 FROM python:3.11-slim
 
+# Version build args
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# OCI image labels
+LABEL org.opencontainers.image.title="Agentium Aider Agent"
+LABEL org.opencontainers.image.description="Aider runtime environment for Agentium"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${COMMIT}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.source="https://github.com/andywolf/agentium"
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
@@ -34,6 +47,9 @@ RUN echo "agentium ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Create workspace
 RUN mkdir -p /workspace && chown agentium:agentium /workspace
+
+# Write version file for runtime introspection
+RUN echo "${VERSION}" > /etc/agentium-version
 
 # Copy runtime installation scripts
 COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh

--- a/docker/claudecode/Dockerfile
+++ b/docker/claudecode/Dockerfile
@@ -3,6 +3,19 @@
 
 FROM node:20-slim
 
+# Version build args
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# OCI image labels
+LABEL org.opencontainers.image.title="Agentium Claude Code Agent"
+LABEL org.opencontainers.image.description="Claude Code runtime environment for Agentium"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${COMMIT}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.source="https://github.com/andywolf/agentium"
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
@@ -50,6 +63,9 @@ RUN echo "agentium ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 # Create workspace and Claude config directory
 RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
     mkdir -p /home/agentium/.claude && chown agentium:agentium /home/agentium/.claude
+
+# Write version file for runtime introspection
+RUN echo "${VERSION}" > /etc/agentium-version
 
 # Configure Claude Code sandbox for container environment
 # - sandbox.enabled=true: Keep sandbox active for security

--- a/docker/codex/Dockerfile
+++ b/docker/codex/Dockerfile
@@ -3,6 +3,19 @@
 
 FROM node:20-slim
 
+# Version build args
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# OCI image labels
+LABEL org.opencontainers.image.title="Agentium Codex Agent"
+LABEL org.opencontainers.image.description="Codex CLI runtime environment for Agentium"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${COMMIT}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.source="https://github.com/andywolf/agentium"
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
@@ -50,6 +63,9 @@ RUN echo "agentium ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 # Create workspace and Codex config directory
 RUN mkdir -p /workspace && chown agentium:agentium /workspace && \
     mkdir -p /home/agentium/.codex && chown agentium:agentium /home/agentium/.codex
+
+# Write version file for runtime introspection
+RUN echo "${VERSION}" > /etc/agentium-version
 
 # Copy runtime installation scripts
 COPY docker/scripts/install-runtime.sh /runtime-scripts/install-runtime.sh

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -4,6 +4,11 @@
 # Build stage
 FROM golang:1.25-alpine AS builder
 
+# Version build args
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /build
 
 # Install dependencies
@@ -16,11 +21,29 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the controller binary
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /agentium-controller ./cmd/controller
+# Build the controller binary with version info
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w \
+      -X github.com/andywolf/agentium/internal/version.Version=${VERSION} \
+      -X github.com/andywolf/agentium/internal/version.Commit=${COMMIT} \
+      -X github.com/andywolf/agentium/internal/version.BuildDate=${BUILD_DATE}" \
+    -o /agentium-controller ./cmd/controller
 
 # Runtime stage
 FROM alpine:3.19
+
+# Version build args for labels and version file
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# OCI image labels
+LABEL org.opencontainers.image.title="Agentium Controller"
+LABEL org.opencontainers.image.description="Session controller for Agentium ephemeral AI agent execution"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${COMMIT}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.source="https://github.com/andywolf/agentium"
 
 # Install runtime dependencies
 RUN apk add --no-cache \
@@ -52,6 +75,9 @@ COPY --from=builder /agentium-controller /usr/local/bin/agentium-controller
 
 # Create workspace directory
 RUN mkdir -p /workspace /etc/agentium && chown agentium:agentium /workspace
+
+# Write version file for runtime introspection
+RUN echo "${VERSION}" > /etc/agentium-version
 
 # Set working directory
 WORKDIR /workspace

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/andywolf/agentium/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -30,6 +31,10 @@ func Execute() error {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Set version for --version flag
+	rootCmd.Version = version.Short()
+	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is .agentium.yaml)")
 	rootCmd.PersistentFlags().Bool("verbose", false, "enable verbose output")

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/andywolf/agentium/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  `Print detailed version information including commit hash and build date.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		if verbose {
+			fmt.Println(version.Full())
+		} else {
+			fmt.Println(version.Info())
+		}
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolP("verbose", "v", false, "print verbose version information")
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/andywolf/agentium/internal/prompt"
 	"github.com/andywolf/agentium/internal/routing"
 	"github.com/andywolf/agentium/internal/scope"
+	"github.com/andywolf/agentium/internal/version"
 	"github.com/andywolf/agentium/internal/workspace"
 	"github.com/andywolf/agentium/prompts/skills"
 )
@@ -59,9 +60,6 @@ const (
 	// MaxIssueBodyLen is the maximum length for issue body text before truncation.
 	MaxIssueBodyLen = 1000
 )
-
-// Version is the controller version, set at build time via ldflags.
-var Version = "dev"
 
 // TaskPhase represents the current phase of a task in its lifecycle
 type TaskPhase string
@@ -538,7 +536,7 @@ func (c *Controller) Run(ctx context.Context) error {
 // - Fetches task details (issues/PRs)
 // - Builds dependency graph
 func (c *Controller) initSession(ctx context.Context) error {
-	c.logInfo("Controller started (version %s)", Version)
+	c.logInfo("Controller started (%s)", version.Info())
 	c.logInfo("Starting session %s", c.config.ID)
 	c.logInfo("Repository: %s", c.config.Repository)
 	if len(c.config.Tasks) > 0 {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,46 @@
+// Package version provides build-time version information for Agentium.
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// Build-time variables set via ldflags.
+// Example: go build -ldflags="-X github.com/andywolf/agentium/internal/version.Version=v1.0.0"
+var (
+	// Version is the semantic version (e.g., "v1.2.3"). Set via ldflags.
+	Version = "dev"
+
+	// Commit is the git commit SHA. Set via ldflags.
+	Commit = "unknown"
+
+	// BuildDate is the RFC3339 timestamp of the build. Set via ldflags.
+	BuildDate = "unknown"
+)
+
+// Short returns the version string (e.g., "v1.2.3" or "dev").
+func Short() string {
+	return Version
+}
+
+// Info returns a single-line version string with commit and build info.
+// Format: "agentium v1.2.3 (commit: abc1234, built: 2024-01-15T10:30:00Z, go: go1.25.x)"
+func Info() string {
+	commitShort := Commit
+	if len(commitShort) > 7 {
+		commitShort = commitShort[:7]
+	}
+	return fmt.Sprintf("agentium %s (commit: %s, built: %s, go: %s)",
+		Version, commitShort, BuildDate, runtime.Version())
+}
+
+// Full returns a multi-line verbose version output.
+func Full() string {
+	return fmt.Sprintf(`agentium %s
+  Commit:     %s
+  Built:      %s
+  Go version: %s
+  OS/Arch:    %s/%s`,
+		Version, Commit, BuildDate, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,110 @@
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestShort(t *testing.T) {
+	// Default value should be "dev"
+	result := Short()
+	if result != Version {
+		t.Errorf("Short() = %q, want %q", result, Version)
+	}
+}
+
+func TestInfo(t *testing.T) {
+	result := Info()
+
+	// Should contain key components
+	if !strings.Contains(result, "agentium") {
+		t.Errorf("Info() should contain 'agentium', got %q", result)
+	}
+	if !strings.Contains(result, Version) {
+		t.Errorf("Info() should contain version %q, got %q", Version, result)
+	}
+	if !strings.Contains(result, "commit:") {
+		t.Errorf("Info() should contain 'commit:', got %q", result)
+	}
+	if !strings.Contains(result, "built:") {
+		t.Errorf("Info() should contain 'built:', got %q", result)
+	}
+	if !strings.Contains(result, runtime.Version()) {
+		t.Errorf("Info() should contain Go version %q, got %q", runtime.Version(), result)
+	}
+}
+
+func TestInfoCommitTruncation(t *testing.T) {
+	// Save original and restore after test
+	originalCommit := Commit
+	defer func() { Commit = originalCommit }()
+
+	// Test with a long commit SHA
+	Commit = "abc123456789abcdef"
+	result := Info()
+
+	// Should contain truncated commit (7 chars)
+	if !strings.Contains(result, "abc1234") {
+		t.Errorf("Info() should contain truncated commit 'abc1234', got %q", result)
+	}
+	// Should NOT contain full commit
+	if strings.Contains(result, "abc123456789abcdef") {
+		t.Errorf("Info() should NOT contain full commit, got %q", result)
+	}
+}
+
+func TestInfoShortCommit(t *testing.T) {
+	// Save original and restore after test
+	originalCommit := Commit
+	defer func() { Commit = originalCommit }()
+
+	// Test with a short commit (less than 7 chars)
+	Commit = "abc"
+	result := Info()
+
+	// Should contain the short commit as-is
+	if !strings.Contains(result, "abc") {
+		t.Errorf("Info() should contain short commit 'abc', got %q", result)
+	}
+}
+
+func TestFull(t *testing.T) {
+	result := Full()
+
+	// Should contain all components
+	if !strings.Contains(result, "agentium") {
+		t.Errorf("Full() should contain 'agentium', got %q", result)
+	}
+	if !strings.Contains(result, Version) {
+		t.Errorf("Full() should contain version %q, got %q", Version, result)
+	}
+	if !strings.Contains(result, "Commit:") {
+		t.Errorf("Full() should contain 'Commit:', got %q", result)
+	}
+	if !strings.Contains(result, "Built:") {
+		t.Errorf("Full() should contain 'Built:', got %q", result)
+	}
+	if !strings.Contains(result, "Go version:") {
+		t.Errorf("Full() should contain 'Go version:', got %q", result)
+	}
+	if !strings.Contains(result, "OS/Arch:") {
+		t.Errorf("Full() should contain 'OS/Arch:', got %q", result)
+	}
+	if !strings.Contains(result, runtime.GOOS) {
+		t.Errorf("Full() should contain OS %q, got %q", runtime.GOOS, result)
+	}
+	if !strings.Contains(result, runtime.GOARCH) {
+		t.Errorf("Full() should contain arch %q, got %q", runtime.GOARCH, result)
+	}
+}
+
+func TestFullMultiLine(t *testing.T) {
+	result := Full()
+
+	// Should be multi-line
+	lines := strings.Split(result, "\n")
+	if len(lines) < 5 {
+		t.Errorf("Full() should have at least 5 lines, got %d: %q", len(lines), result)
+	}
+}


### PR DESCRIPTION
## Summary

- Create `internal/version` package with `Version`, `Commit`, `BuildDate` variables and helper functions (`Info()`, `Short()`, `Full()`)
- Add `agentium version` subcommand with `-v/--verbose` flag for detailed output
- Add `--version` flag to root command via Cobra's built-in support
- Update controller to use centralized version package instead of local `var Version`
- Fix CI/CD workflows to inject version info via ldflags with correct package path
- Add OCI labels (`org.opencontainers.image.version`, `.revision`, `.created`) to all 4 Dockerfiles
- Add `/etc/agentium-version` file to all container images for runtime introspection

## Test plan

- [x] Build compiles successfully: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Development build shows "dev": `./agentium version` → `agentium dev (commit: unknown, built: unknown, go: go1.25.x)`
- [x] Release-style build shows injected values:
  ```bash
  VERSION=v1.0.0 COMMIT=$(git rev-parse HEAD) BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
  go build -ldflags="-X github.com/andywolf/agentium/internal/version.Version=${VERSION} ..." ./cmd/agentium
  ./agentium version
  # → agentium v1.0.0 (commit: 90ebbcc, built: 2026-02-05T17:42:23Z, go: go1.25.6)
  ```
- [ ] After merge, Docker container version can be queried:
  - `docker run --rm <image> cat /etc/agentium-version`
  - `docker inspect <image> --format '{{index .Config.Labels "org.opencontainers.image.version"}}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)