### PR TITLE
Fix auth file ownership in cloud mode

### DIFF
--- a/internal/controller/docker_interactive.go
+++ b/internal/controller/docker_interactive.go
@@ -148,5 +148,17 @@ func (c *Controller) writeInteractiveAuthFile(filename, base64Data string) (stri
 		return "", fmt.Errorf("failed to write auth file: %w", err)
 	}
 
+	// When running as root (cloud mode), chown the auth files to agentium user
+	// so agent containers can read them. The controller runs as root but agent
+	// containers run as agentium (uid=1000).
+	if os.Getuid() == 0 {
+		if err := os.Chown(authDir, AgentiumUID, AgentiumGID); err != nil {
+			return "", fmt.Errorf("failed to chown auth directory: %w", err)
+		}
+		if err := os.Chown(authPath, AgentiumUID, AgentiumGID); err != nil {
+			return "", fmt.Errorf("failed to chown auth file: %w", err)
+		}
+	}
+
 	return authPath, nil
 }


### PR DESCRIPTION
## Summary
- Fix regression from PR #364 where workspace-based auth files were created as root in cloud mode
- Agent containers (running as agentium user) couldn't read auth files → "Permission denied (os error 13)"
- Add chown calls to set auth file ownership to agentium (uid=1000) when running as root

## Root Cause
The `writeInteractiveAuthFile` function creates `.agentium-auth/` directory and auth files in the workspace. In cloud mode:
1. Controller runs as **root**
2. Files are created with `0700`/`0600` permissions owned by **root**
3. Agent containers run as **agentium** (uid=1000)
4. Agents cannot read the files → "Permission denied"

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy to GCP and verify auth works

🤖 Generated with [Claude Code](https://claude.com/claude-code)