### PR TITLE
Fix Docker build context for agent images in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,13 +95,13 @@ jobs:
             context: .
             file: docker/controller/Dockerfile
           - name: claudecode
-            context: docker/claudecode
+            context: .
             file: docker/claudecode/Dockerfile
           - name: aider
-            context: docker/aider
+            context: .
             file: docker/aider/Dockerfile
           - name: codex
-            context: docker/codex
+            context: .
             file: docker/codex/Dockerfile
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix Docker build failing with "docker/scripts/*.sh: not found"
- Agent Dockerfiles use `COPY docker/scripts/...` requiring repo root context
- Release workflow incorrectly set context to agent subdirectory (e.g., `docker/claudecode`)
- Changed all agent images to use `context: .` like the controller image

## Root Cause
The release workflow set the build context incorrectly:
```yaml
- name: claudecode
  context: docker/claudecode  # Wrong - scripts are at repo root
```

Should be:
```yaml
- name: claudecode
  context: .  # Correct - matches controller
```

## Test plan
- [ ] Retag and trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)