### PR TITLE
feat: Give judge access to its own prior ITERATE directives

### DIFF
--- a/internal/controller/phase_loop.go
+++ b/internal/controller/phase_loop.go
@@ -445,13 +445,20 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 			reviewFeedbackComment := SummarizeForComment(reviewResult.Feedback, 250)
 			c.postReviewFeedbackForPhase(ctx, currentPhase, iter, reviewFeedbackComment)
 
+			priorDirectives := ""
+			if c.memoryStore != nil && iter > 1 {
+				taskID := taskKey(c.activeTaskType, c.activeTask)
+				priorDirectives = c.memoryStore.BuildJudgeHistoryContext(taskID, iter)
+			}
+
 			judgeResult, err := c.runJudge(ctx, judgeRunParams{
-				CompletedPhase: currentPhase,
-				PhaseOutput:    phaseOutput,
-				ReviewFeedback: reviewResult.Feedback,
-				Iteration:      iter,
-				MaxIterations:  maxIter,
-				PhaseIteration: iter,
+				CompletedPhase:  currentPhase,
+				PhaseOutput:     phaseOutput,
+				ReviewFeedback:  reviewResult.Feedback,
+				Iteration:       iter,
+				MaxIterations:   maxIter,
+				PhaseIteration:  iter,
+				PriorDirectives: priorDirectives,
 			})
 			if err != nil {
 				c.logWarning("Judge error for phase %s: %v (defaulting to ADVANCE)", currentPhase, err)

--- a/prompts/skills/judge.md
+++ b/prompts/skills/judge.md
@@ -30,6 +30,17 @@ You are the **judge**. Your role is to interpret the reviewer's feedback and dec
 - On middle iterations: Balance quality with forward progress.
 - On final iterations: Prefer ADVANCE unless there are critical issues that would prevent the work from being usable. Diminishing returns from further iteration.
 
+### Iteration History Awareness
+
+When prior directives are provided, compare them against the reviewer's current feedback:
+
+- If the reviewer raises NEW issues not previously flagged → they may warrant ITERATE
+- If the reviewer is repeating concerns you already raised → the worker is stuck;
+  ITERATE with guidance to try a different approach rather than repeating the same fix
+- If your prior directives have been addressed and only minor/cosmetic issues remain → ADVANCE
+- Each additional iteration has diminishing returns — the bar for ITERATE should
+  increase with each iteration
+
 ### Verdict Format
 
 You MUST emit exactly one verdict line in this format:


### PR DESCRIPTION
## Summary

- Add `BuildJudgeHistoryContext` to memory store — returns only `JudgeDirective` entries from prior phase iterations, formatted with `[iter N]` tags, budget-aware and task-scoped
- Add `PriorDirectives` field to `judgeRunParams` and render a **"Your Prior Directives"** section in the judge prompt (between iteration counter and reviewer feedback)
- Remove redundant `BuildCurrentIterationEvalContext` injection in `runJudge` (was a no-op since the current iteration's `EvalFeedback` hasn't been stored yet when the judge runs)
- Add **Iteration History Awareness** guidance to `judge.md` prompt so the judge can detect stuck loops and redirect the worker
- Add 10 new tests across `context_test.go` and `judge_test.go`

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all tests pass
- [ ] Verify `judge_test.go`: prompt on iteration 1 has NO "Prior Directives" section
- [ ] Verify `judge_test.go`: prompt on iteration 3 shows directives from iter 1 and 2
- [ ] Verify `context_test.go`: `BuildJudgeHistoryContext` correctly filters by type and iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)