### PR TITLE
Improve W-R-J prompts: security criteria, code inspection, severity overrides, approach guidance

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1759,6 +1759,10 @@ func (c *Controller) buildIterateFeedbackSection(taskID string, phaseIteration i
 	sb.WriteString("**How to use this feedback:**\n")
 	sb.WriteString("- **Reviewer feedback**: Detailed analysis - consider all points as context\n")
 	sb.WriteString("- **Judge directives**: Required action items - you MUST address these\n\n")
+	sb.WriteString("**Approach:**\n")
+	sb.WriteString("- Your implementation already exists on this branch. Run `git log --oneline main..HEAD` and `git diff main..HEAD` to review your existing work before making changes.\n")
+	sb.WriteString("- Make **targeted, surgical fixes** to address the feedback. Do not rewrite or start over unless the judge directive explicitly says to take a different approach.\n")
+	sb.WriteString("- If a directive asks for a specific fix, make that fix and nothing else. If it asks to reconsider the approach, then a broader change is warranted.\n\n")
 
 	// Separate reviewer feedback and judge directives
 	var reviewerFeedback, judgeDirectives []string

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1369,6 +1369,7 @@ func TestBuildIterateFeedbackSection(t *testing.T) {
 				"### Reviewer Analysis (Context)",
 				"Address the test coverage gap",
 				"**How to use this feedback:**",
+				"targeted, surgical fixes",
 			},
 		},
 		{

--- a/internal/controller/judge.go
+++ b/internal/controller/judge.go
@@ -253,7 +253,7 @@ func (c *Controller) buildJudgePrompt(params judgeRunParams) string {
 	sb.WriteString("\n")
 
 	if params.Iteration >= params.MaxIterations {
-		sb.WriteString("**NOTE:** This is the FINAL iteration. Prefer ADVANCE unless there are critical issues that would prevent the work from being usable.\n\n")
+		sb.WriteString("**NOTE:** This is the FINAL iteration. Prefer ADVANCE unless there are critical issues that would prevent the work from being usable. However, security issues (data leakage to external services, missing input sanitization) are ALWAYS critical regardless of iteration count.\n\n")
 	}
 
 	return sb.String()

--- a/internal/controller/judge_test.go
+++ b/internal/controller/judge_test.go
@@ -243,6 +243,9 @@ func TestBuildJudgePrompt_FinalIteration(t *testing.T) {
 	if !containsString(prompt, "Prefer ADVANCE") {
 		t.Error("buildJudgePrompt() should tell judge to prefer ADVANCE on final iteration")
 	}
+	if !containsString(prompt, "security issues") {
+		t.Error("buildJudgePrompt() should mention security issues override on final iteration")
+	}
 }
 
 func TestBuildJudgePrompt_EmptyReviewFeedback(t *testing.T) {

--- a/internal/controller/reviewer.go
+++ b/internal/controller/reviewer.go
@@ -182,8 +182,14 @@ func (c *Controller) buildReviewPrompt(params reviewRunParams) string {
 	sb.WriteString("\n```\n\n")
 
 	sb.WriteString("## Your Task\n\n")
-	sb.WriteString("Provide constructive, actionable review feedback on the phase output above.\n")
-	sb.WriteString("Be specific about what to improve and indicate severity where relevant (e.g., critical bug, minor style issue, can be deferred).\n\n")
+	sb.WriteString("Review the code changes produced in this phase.\n\n")
+	sb.WriteString("**IMPORTANT:** Do not rely solely on the phase output log above. The log shows agent activity, not a clean view of the code. You MUST:\n")
+	sb.WriteString("1. Run `git diff main..HEAD` to see all code changes on this branch\n")
+	sb.WriteString("2. Open and read key modified files to check surrounding context\n")
+	sb.WriteString("3. Verify that the changes match what the worker claims to have done\n\n")
+	sb.WriteString("Provide constructive, actionable review feedback.\n")
+	sb.WriteString("Be specific about what to improve and indicate severity (critical/security, functional bug, minor style).\n")
+	sb.WriteString("Security issues (data leakage, missing input validation, unguarded nil access) should always be flagged as critical.\n\n")
 
 	sb.WriteString("## Output Format\n\n")
 	sb.WriteString("**CRITICAL:** Output ONLY your feedback. Do NOT include:\n")

--- a/internal/controller/reviewer_test.go
+++ b/internal/controller/reviewer_test.go
@@ -26,8 +26,8 @@ func TestBuildReviewPrompt(t *testing.T) {
 		"github.com/org/repo",
 		"#42",
 		"modify auth.go",
-		"constructive, actionable review feedback",
-		"indicate severity where relevant",
+		"git diff main..HEAD",
+		"Security issues",
 	}
 	for _, substr := range contains {
 		if !containsString(prompt, substr) {

--- a/prompts/skills/code_reviewer.md
+++ b/prompts/skills/code_reviewer.md
@@ -10,8 +10,11 @@ You are reviewing **code changes** produced by an agent during the REVIEW phase.
 - **Test Coverage:** Do all tests pass? Are the new changes adequately covered by tests?
 - **Quality:** Are error cases handled? Is the code readable and maintainable? Does it follow the codebase's existing patterns?
 - **Architecture:** Are there any design issues that should be addressed before merging?
+- **Security & Data Flow:** When code sends data to external services (logging platforms, APIs, cloud services), verify that sensitive content (secrets, command outputs, tool results) is not leaked. Check that only safe summaries cross trust boundaries, not full content.
+- **Production Hardening:** Check for nil/empty input guards on public functions, edge cases in string parsing (empty strings, trailing delimiters), file permission enforcement on both new and existing files, unused parameters, and platform-specific constraints (e.g., label length limits) when integrating with external services.
 - **Scope:** Are all the changes necessary to close the issue? Flag any modifications that appear unrelated to the issue requirements — "drive-by" fixes, unnecessary refactoring, or gold-plating.
 - **Commit Quality:** Check the commit history. Are there "fix" commits that repair previous commits in the same PR? This indicates the agent committed before validating. Flag patterns like "fix test", "fix lint", "fix build" commits.
+- **Documentation Accuracy:** Do help text, examples, and CLI flag descriptions reference correct values? Check that phase names, flag options, and example commands are valid.
 
 ### Guidelines
 
@@ -20,6 +23,7 @@ You are reviewing **code changes** produced by an agent during the REVIEW phase.
 - Distinguish between critical issues (would cause failures) and minor improvements (nice to have)
 - If the implementation looks good, say so briefly and note any minor improvements
 - Focus on functional correctness over style preferences
+- **Read the actual code changes** — do not rely solely on the phase output log. Run `git diff main..HEAD` to see what changed. Open key modified files to check surrounding context. The phase output shows agent activity, not a clean view of the code.
 - For significant architectural issues, recommend returning to the planning phase (REGRESS)
 - If you see changes that don't relate to the issue requirements, flag them explicitly
 - "Good code that wasn't asked for" is still a problem — it adds review burden and risk

--- a/prompts/skills/judge.md
+++ b/prompts/skills/judge.md
@@ -30,6 +30,15 @@ You are the **judge**. Your role is to interpret the reviewer's feedback and dec
 - On middle iterations: Balance quality with forward progress.
 - On final iterations: Prefer ADVANCE unless there are critical issues that would prevent the work from being usable. Diminishing returns from further iteration.
 
+### Severity-Based Overrides
+
+Not all issues are subject to iteration pressure:
+
+- **Security issues (data leakage, secrets exposure, missing sensitivity filtering):** ALWAYS ITERATE regardless of iteration count. A PR with a security flaw is worse than an extra iteration.
+- **External service integration bugs (violated platform constraints, broken query parsing):** ITERATE. These cause runtime failures in production.
+- **Nil safety / crash risks:** ITERATE on all but the final iteration.
+- **Documentation inaccuracies:** Flag but do not block on final iterations.
+
 ### Iteration History Awareness
 
 When prior directives are provided, compare them against the reviewer's current feedback:

--- a/prompts/skills/test.md
+++ b/prompts/skills/test.md
@@ -25,11 +25,13 @@ Repeat the following cycle until all tests pass and code is ready:
 #### 6b. Review Your Own Code
 Before committing, critically review your changes:
 - Does the code correctly implement the issue requirements?
-- Are there any edge cases not handled?
+- Are there edge cases not handled? (nil inputs, empty strings, trailing delimiters, whitespace-only values)
 - Is the code readable and maintainable?
-- Are there any security concerns?
 - Does it follow the project's coding conventions?
-- Are error cases handled appropriately?
+- **Data sensitivity:** If the code logs or sends data to external services, does it separate sensitive content (full command output, tool results) from safe summaries? Only summaries should cross trust boundaries.
+- **External service constraints:** If integrating with external services, are platform limits respected? (e.g., label length limits, payload size restrictions). Prefer truncation over rejection.
+- **Defensive coding:** Do public functions guard against nil arguments? Do file operations handle pre-existing files with wrong permissions? Are unused parameters removed?
+- **Documentation:** Do help text, examples, and comments reference valid values? (correct phase names, valid flag combinations, accurate type lists)
 
 #### 6c. Fix Issues Found
 If tests fail or review reveals problems:


### PR DESCRIPTION
## Summary

- **Reviewer now inspects actual code** — directed to run `git diff main..HEAD` and read modified files instead of only reviewing the truncated phase output log
- **Security & hardening criteria added** to reviewer and worker self-review checklists (data flow sensitivity, nil guards, platform constraints, documentation accuracy)
- **Judge severity overrides** ensure security issues always trigger ITERATE regardless of iteration count
- **Approach guidance** tells workers on iteration 2+ to make targeted, surgical fixes instead of starting over

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes with updated assertions
- [x] `TestBuildReviewPrompt` asserts `git diff main..HEAD` and `Security issues` are present
- [x] `TestBuildJudgePrompt_FinalIteration` asserts `security issues` clause is present
- [x] `TestBuildIterateFeedbackSection` asserts `targeted, surgical fixes` is present

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)