### PR TITLE
fix: Strip stream-of-thought content from GitHub comments

### DIFF
--- a/internal/controller/summarize_test.go
+++ b/internal/controller/summarize_test.go
@@ -115,6 +115,150 @@ Third explanation.`,
 	}
 }
 
+func TestStripAgentiumSignals(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+		excludes string
+		want     string // exact match (empty = skip exact check)
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:     "removes STATUS signal",
+			input:    "Some text\nAGENTIUM_STATUS: COMPLETE All done\nMore text",
+			contains: "More text",
+			excludes: "AGENTIUM_STATUS",
+		},
+		{
+			name:     "removes MEMORY signal",
+			input:    "Some text\nAGENTIUM_MEMORY: FEEDBACK_RESPONSE ADDRESSED fixed the bug\nMore text",
+			contains: "More text",
+			excludes: "AGENTIUM_MEMORY",
+		},
+		{
+			name: "removes multi-line HANDOFF block",
+			input: `Plan summary here.
+
+AGENTIUM_HANDOFF: {
+  "summary": "Add feature X",
+  "files_to_modify": ["a.go"]
+}
+
+Next section.`,
+			contains: "Next section",
+			excludes: "AGENTIUM_HANDOFF",
+		},
+		{
+			name:     "preserves non-signal content",
+			input:    "This is a normal plan.\nWith multiple lines.\nNo signals here.",
+			contains: "With multiple lines",
+		},
+		{
+			name: "removes multiple signal types",
+			input: `Start
+AGENTIUM_STATUS: WORKING on plan
+Middle
+AGENTIUM_MEMORY: FEEDBACK_RESPONSE DECLINED not needed
+End`,
+			contains: "End",
+			excludes: "AGENTIUM_STATUS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripAgentiumSignals(tt.input)
+			if tt.want != "" && got != tt.want {
+				t.Errorf("StripAgentiumSignals() = %q, want %q", got, tt.want)
+			}
+			if tt.contains != "" && !strings.Contains(got, tt.contains) {
+				t.Errorf("StripAgentiumSignals() should contain %q, got:\n%s", tt.contains, got)
+			}
+			if tt.excludes != "" && strings.Contains(got, tt.excludes) {
+				t.Errorf("StripAgentiumSignals() should NOT contain %q, got:\n%s", tt.excludes, got)
+			}
+		})
+	}
+}
+
+func TestStripPreamble(t *testing.T) {
+	tests := []struct {
+		name string
+		input string
+		want string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "no preamble",
+			input: "## Plan Summary\n\nHere is the plan.",
+			want:  "## Plan Summary\n\nHere is the plan.",
+		},
+		{
+			name:  "strips Let me preamble",
+			input: "Let me analyze the codebase.\n\n## Plan Summary\n\nHere is the plan.",
+			want:  "## Plan Summary\n\nHere is the plan.",
+		},
+		{
+			name:  "strips multiple preamble lines",
+			input: "Excellent - I now have a comprehensive understanding.\nLet me create the plan.\n\n## Plan Summary\n\nHere is the plan.",
+			want:  "## Plan Summary\n\nHere is the plan.",
+		},
+		{
+			name:  "strips preamble with blank lines between",
+			input: "I'll review the changes.\n\nLooking at the code...\n\n## Feedback\n\nThe code looks good.",
+			want:  "## Feedback\n\nThe code looks good.",
+		},
+		{
+			name:  "all preamble returns empty",
+			input: "Let me think about this.\nI need to analyze more.\nExcellent progress.",
+			want:  "",
+		},
+		{
+			name:  "preserves content starting with markdown header",
+			input: "## Review Feedback\n\n- Issue 1\n- Issue 2",
+			want:  "## Review Feedback\n\n- Issue 1\n- Issue 2",
+		},
+		{
+			name:  "strips file operation lines",
+			input: "File created successfully.\nFile updated at path/to/file.\n\n## Summary\n\nDone.",
+			want:  "## Summary\n\nDone.",
+		},
+		{
+			name:  "case insensitive matching",
+			input: "LOOKING AT the implementation...\n\n## Plan\n\nStep 1.",
+			want:  "## Plan\n\nStep 1.",
+		},
+		{
+			name:  "I now have preamble",
+			input: "I now have a comprehensive understanding of the codebase.\n\n## Plan\n\nDo things.",
+			want:  "## Plan\n\nDo things.",
+		},
+		{
+			name:  "based on preamble",
+			input: "Based on my analysis of the issue.\n\n## Plan\n\nDo things.",
+			want:  "## Plan\n\nDo things.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripPreamble(tt.input)
+			if got != tt.want {
+				t.Errorf("StripPreamble() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSummarizeForComment_MaxLinesZero(t *testing.T) {
 	content := "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
 	got := SummarizeForComment(content, 0)

--- a/prompts/skills/code_reviewer.md
+++ b/prompts/skills/code_reviewer.md
@@ -30,6 +30,8 @@ You are reviewing **code changes** produced by an agent during the REVIEW phase.
 
 ### Output
 
+**CRITICAL:** Do NOT include preamble or process descriptions. Start directly with your feedback. Do not begin with "Let me review...", "I'll examine...", or similar phrases.
+
 Provide your review feedback below. Be specific about what to improve.
 
 For critical architectural issues that require re-planning, clearly state: "Recommend REGRESS to PLAN phase: <reason>"

--- a/prompts/skills/docs_reviewer.md
+++ b/prompts/skills/docs_reviewer.md
@@ -31,6 +31,8 @@ You are reviewing **documentation changes** produced by an agent during the DOCS
 
 ### Output
 
+**CRITICAL:** Do NOT include preamble or process descriptions. Start directly with your feedback. Do not begin with "Let me review...", "I'll examine...", or similar phrases.
+
 Provide your review feedback below. Be specific about what to improve.
 
 For documentation that looks good or was correctly skipped, say so briefly.

--- a/prompts/skills/plan_reviewer.md
+++ b/prompts/skills/plan_reviewer.md
@@ -25,4 +25,6 @@ Plans describe approach, not implementation code. Do not request code snippets, 
 
 ### Output
 
+**CRITICAL:** Do NOT include preamble or process descriptions. Start directly with your feedback. Do not begin with "Let me review...", "I'll examine...", or similar phrases.
+
 Provide your review feedback below. Be specific about what to improve.


### PR DESCRIPTION
## Summary

- **Reviewer feedback now uses `AssistantText`** instead of `RawTextContent`, eliminating tool results (diffs, file contents, git output) from reviewer comments — the single biggest source of noise
- **Added `StripAgentiumSignals()`** to remove `AGENTIUM_STATUS:`, `AGENTIUM_MEMORY:`, and multi-line `AGENTIUM_HANDOFF: {...}` blocks from content before posting
- **Added `StripPreamble()`** to strip leading conversational/stream-of-thought lines (e.g., "Let me...", "Excellent...", "Looking at...") that agents produce before substantive output
- **Applied both filters** in the worker and reviewer comment pipelines before `SummarizeForComment()`
- **Implementation plan comments** now render structured handoff `PlanOutput` as clean markdown when available, with fallback to signal-stripped raw output
- **Added "no preamble" instructions** to all three reviewer skill prompts (plan, code, docs)
- **Added 17 test cases** for `StripAgentiumSignals` and `StripPreamble`

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/controller/...` — all tests pass including new ones
- [ ] Manual: verify reviewer comments no longer contain diffs/file contents
- [ ] Manual: verify worker phase comments have preamble stripped
- [ ] Manual: verify implementation plan comments render as structured markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)