### PR TITLE
feat: Add role identification to comments & remove worker complexity self-declaration

### DIFF
--- a/internal/controller/comments_test.go
+++ b/internal/controller/comments_test.go
@@ -22,7 +22,7 @@ func TestPostPhaseComment_OnlyForIssues(t *testing.T) {
 	}
 
 	// Should not panic or crash - just return silently
-	c.postPhaseComment(context.Background(), PhaseImplement, 1, "test summary")
+	c.postPhaseComment(context.Background(), PhaseImplement, 1, RoleWorker, "test summary")
 }
 
 func TestPostJudgeComment_OnlyForIssues(t *testing.T) {
@@ -33,7 +33,7 @@ func TestPostJudgeComment_OnlyForIssues(t *testing.T) {
 	}
 
 	// Should not panic or crash - just return silently
-	c.postJudgeComment(context.Background(), PhaseImplement, JudgeResult{Verdict: VerdictAdvance})
+	c.postJudgeComment(context.Background(), PhaseImplement, 1, JudgeResult{Verdict: VerdictAdvance})
 }
 
 func TestJudgeResultFormatting(t *testing.T) {
@@ -102,7 +102,7 @@ func TestPostPRJudgeVerdict_SkipsAdvance(t *testing.T) {
 	}
 
 	// Should not attempt to post for ADVANCE verdict
-	c.postPRJudgeVerdict(context.Background(), "123", PhaseImplement, JudgeResult{Verdict: VerdictAdvance})
+	c.postPRJudgeVerdict(context.Background(), "123", PhaseImplement, 1, JudgeResult{Verdict: VerdictAdvance})
 }
 
 func TestPostPRJudgeVerdict_EmptyPRNumber(t *testing.T) {
@@ -114,7 +114,7 @@ func TestPostPRJudgeVerdict_EmptyPRNumber(t *testing.T) {
 	}
 
 	// Should not panic or crash - just return silently
-	c.postPRJudgeVerdict(context.Background(), "", PhaseImplement, JudgeResult{Verdict: VerdictIterate, Feedback: "needs work"})
+	c.postPRJudgeVerdict(context.Background(), "", PhaseImplement, 1, JudgeResult{Verdict: VerdictIterate, Feedback: "needs work"})
 }
 
 func TestGetPRNumberForTask(t *testing.T) {

--- a/internal/handoff/handoff_test.go
+++ b/internal/handoff/handoff_test.go
@@ -354,22 +354,6 @@ func TestValidator(t *testing.T) {
 		}
 	})
 
-	t.Run("ValidatePlanOutput invalid complexity", func(t *testing.T) {
-		out := &PlanOutput{
-			Summary:         "Plan",
-			TestingApproach: "unit tests",
-			Complexity:      "INVALID",
-			ImplementationSteps: []ImplementationStep{
-				{Order: 1, Description: "Step 1"},
-			},
-		}
-
-		errs := validator.ValidatePhaseOutput(PhasePlan, out)
-		if !errs.HasErrors() {
-			t.Error("Expected validation error for invalid complexity")
-		}
-	})
-
 	t.Run("ValidateImplementOutput success", func(t *testing.T) {
 		out := &ImplementOutput{
 			BranchName:   "feature/test",

--- a/internal/handoff/types.go
+++ b/internal/handoff/types.go
@@ -49,7 +49,6 @@ type PlanOutput struct {
 	FilesToCreate       []string             `json:"files_to_create"`
 	ImplementationSteps []ImplementationStep `json:"implementation_steps"`
 	TestingApproach     string               `json:"testing_approach"`
-	Complexity          string               `json:"complexity,omitempty"` // SIMPLE or COMPLEX
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/handoff/validator.go
+++ b/internal/handoff/validator.go
@@ -118,11 +118,6 @@ func (v *Validator) validatePlanOutput(out *PlanOutput) ValidationErrors {
 		errs = append(errs, ValidationError{Phase: PhasePlan, Field: "testing_approach", Message: "testing approach is required"})
 	}
 
-	// Validate complexity if set
-	if out.Complexity != "" && out.Complexity != "SIMPLE" && out.Complexity != "COMPLEX" {
-		errs = append(errs, ValidationError{Phase: PhasePlan, Field: "complexity", Message: "complexity must be SIMPLE or COMPLEX"})
-	}
-
 	return errs
 }
 

--- a/prompts/skills/plan.md
+++ b/prompts/skills/plan.md
@@ -25,6 +25,7 @@ Your plan should include:
 - Focus solely on understanding the problem and designing the solution
 - Be specific about file paths and function names where possible
 - Consider edge cases and backward compatibility
+- Do NOT assess or declare the complexity of the task (SIMPLE/COMPLEX) — a separate Complexity Assessor agent handles this
 
 ### Planning Rigor
 
@@ -54,8 +55,7 @@ AGENTIUM_HANDOFF: {
     {"order": 1, "description": "Step 1 description", "file": "path/to/file.go"},
     {"order": 2, "description": "Step 2 description", "file": "path/to/file.go"}
   ],
-  "testing_approach": "How the changes will be verified",
-  "complexity": "SIMPLE or COMPLEX"
+  "testing_approach": "How the changes will be verified"
 }
 ```
 


### PR DESCRIPTION
## Summary

- **Add role identification to all GitHub issue/PR comments**: Every comment now includes a consistent header `### Phase: {PHASE} — {Role} (iteration N)` identifying whether it was posted by the Worker, Complexity Assessor, Reviewer, Judge, or Controller
- **Remove worker complexity self-declaration**: The plan skill no longer instructs the worker to emit a `complexity` field in its handoff signal — complexity assessment is handled exclusively by the separate Complexity Assessor agent
- **Consistent comment format**: Judge and reviewer comments on both issues and PRs now use the same `### Phase:` header pattern instead of varying ad-hoc formats

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 27 packages)
- [ ] Deploy and verify comment formatting on a test issue


🤖 Generated with [Claude Code](https://claude.com/claude-code)