### PR TITLE
fix: Pass --max-duration to Terraform and fix CLI flag precedence

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -101,10 +101,12 @@ func runSession(cmd *cobra.Command, args []string) error {
 	if agent := viper.GetString("session.agent"); agent != "" {
 		cfg.Session.Agent = agent
 	}
-	if maxIter := viper.GetInt("session.max_iterations"); maxIter > 0 {
+	if cmd.Flags().Changed("max-iterations") {
+		maxIter, _ := cmd.Flags().GetInt("max-iterations")
 		cfg.Session.MaxIterations = maxIter
 	}
-	if maxDur := viper.GetString("session.max_duration"); maxDur != "" {
+	if cmd.Flags().Changed("max-duration") {
+		maxDur, _ := cmd.Flags().GetString("max-duration")
 		cfg.Session.MaxDuration = maxDur
 	}
 	if provider := viper.GetString("cloud.provider"); provider != "" {

--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -54,10 +54,12 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	if agent := viper.GetString("session.agent"); agent != "" {
 		cfg.Session.Agent = agent
 	}
-	if maxIter := viper.GetInt("session.max_iterations"); maxIter > 0 {
+	if cmd.Flags().Changed("max-iterations") {
+		maxIter, _ := cmd.Flags().GetInt("max-iterations")
 		cfg.Session.MaxIterations = maxIter
 	}
-	if maxDur := viper.GetString("session.max_duration"); maxDur != "" {
+	if cmd.Flags().Changed("max-duration") {
+		maxDur, _ := cmd.Flags().GetString("max-duration")
 		cfg.Session.MaxDuration = maxDur
 	}
 	if prompt, _ := cmd.Flags().GetString("prompt"); prompt != "" {


### PR DESCRIPTION
## Summary

- **GCP provisioner now passes `max_run_duration` to Terraform tfvars**, converting the Go duration format (e.g. `6h`) to seconds (e.g. `21600s`). Previously, the Terraform default of `7200s` (2h) always applied, causing VMs to be killed at 2 hours regardless of the `--max-duration` flag.
- **Fixes CLI flag precedence for `--max-duration` and `--max-iterations`** by switching from `viper.GetString()`/`viper.GetInt()` to `cmd.Flags().Changed()`. The old approach couldn't distinguish between a user-set flag value and the flag's default, so config file defaults were always overwritten.
- Applied the same fix to both `run.go` (cloud) and `run_local.go` (local) code paths.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `agentium run --max-duration 6h --dry-run` and verify "Max duration: 6h" is printed
- [ ] Run `agentium run --dry-run` (no flag) and verify config file default `2h` is used
- [ ] Deploy and verify VM stays alive beyond 2h when `--max-duration 6h` is passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)