### PR TITLE
feat: Add --auto-merge CLI flag with VERIFY phase

### DIFF
--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -68,6 +68,10 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	if authMode := viper.GetString("claude.auth_mode"); authMode != "" {
 		cfg.Claude.AuthMode = authMode
 	}
+	if cmd.Flags().Changed("auto-merge") {
+		autoMerge, _ := cmd.Flags().GetBool("auto-merge")
+		cfg.Session.AutoMerge = autoMerge
+	}
 
 	// Validate configuration for local run (relaxed validation)
 	if err = cfg.ValidateForLocalRun(); err != nil {
@@ -100,6 +104,9 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("Workspace: %s\n", workDir)
 	fmt.Printf("Max iterations: %d\n", cfg.Session.MaxIterations)
 	fmt.Printf("Max duration: %s\n", cfg.Session.MaxDuration)
+	if cfg.Session.AutoMerge {
+		fmt.Println("Auto-merge: enabled")
+	}
 	fmt.Println()
 	fmt.Println("Running in local interactive mode - agent will prompt for permission approvals")
 	fmt.Println()
@@ -142,6 +149,7 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 		Interactive:          true, // Enable interactive mode
 		CloneInsideContainer: true, // Clone inside Docker container for reliable auth
 		Verbose:              viper.GetBool("verbose"),
+		AutoMerge:            cfg.Session.AutoMerge,
 	}
 
 	// Set Claude auth config
@@ -156,6 +164,7 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 		PlanMaxIterations:      cfg.PhaseLoop.PlanMaxIterations,
 		ImplementMaxIterations: cfg.PhaseLoop.ImplementMaxIterations,
 		DocsMaxIterations:      cfg.PhaseLoop.DocsMaxIterations,
+		VerifyMaxIterations:    cfg.PhaseLoop.VerifyMaxIterations,
 		JudgeContextBudget:     cfg.PhaseLoop.JudgeContextBudget,
 		JudgeNoSignalLimit:     cfg.PhaseLoop.JudgeNoSignalLimit,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type PhaseLoopConfig struct {
 	ImplementMaxIterations int  `mapstructure:"implement_max_iterations"`
 	ReviewMaxIterations    int  `mapstructure:"review_max_iterations"`
 	DocsMaxIterations      int  `mapstructure:"docs_max_iterations"`
+	VerifyMaxIterations    int  `mapstructure:"verify_max_iterations"`
 	JudgeContextBudget     int  `mapstructure:"judge_context_budget"`
 	JudgeNoSignalLimit     int  `mapstructure:"judge_no_signal_limit"`
 }
@@ -105,6 +106,7 @@ type SessionConfig struct {
 	MaxIterations int      `mapstructure:"max_iterations"`
 	MaxDuration   string   `mapstructure:"max_duration"`
 	Prompt        string   `mapstructure:"prompt"`
+	AutoMerge     bool     `mapstructure:"auto_merge"`
 }
 
 // ControllerConfig contains session controller settings

--- a/internal/controller/draft_pr_test.go
+++ b/internal/controller/draft_pr_test.go
@@ -137,6 +137,26 @@ func TestMaybeCreateDraftPR_ErrorsOnMissingState(t *testing.T) {
 	}
 }
 
+func TestFinalizeDraftPR_SkipsWhenPRMerged(t *testing.T) {
+	c := &Controller{
+		taskStates: map[string]*TaskState{
+			"issue:123": {
+				ID:       "123",
+				Type:     "issue",
+				PRNumber: "42",
+				PRMerged: true,
+			},
+		},
+		logger: newTestLogger(),
+	}
+
+	// Should return nil without doing anything (PR already merged)
+	err := c.finalizeDraftPR(context.TODO(), "issue:123")
+	if err != nil {
+		t.Errorf("expected nil error when PR already merged, got %v", err)
+	}
+}
+
 func TestFinalizeDraftPR_SkipsWhenNoPRNumber(t *testing.T) {
 	c := &Controller{
 		taskStates: map[string]*TaskState{

--- a/internal/handoff/builders.go
+++ b/internal/handoff/builders.go
@@ -28,6 +28,8 @@ func (b *Builder) BuildInputForPhase(taskID string, phase Phase) (string, error)
 		input, err = b.buildImplementInput(taskID)
 	case PhaseDocs:
 		input, err = b.buildDocsInput(taskID)
+	case PhaseVerify:
+		input, err = b.buildVerifyInput(taskID)
 	default:
 		return "", fmt.Errorf("unknown phase: %s", phase)
 	}
@@ -117,6 +119,26 @@ func (b *Builder) buildDocsInput(taskID string) (*DocsInput, error) {
 		Issue:        *issue,
 		PlanSummary:  plan.Summary,
 		FilesChanged: impl.FilesChanged,
+	}, nil
+}
+
+// buildVerifyInput constructs input for the VERIFY phase.
+func (b *Builder) buildVerifyInput(taskID string) (*VerifyInput, error) {
+	issue := b.store.GetIssueContext(taskID)
+	if issue == nil {
+		return nil, fmt.Errorf("no issue context found for task %s", taskID)
+	}
+
+	impl := b.store.GetImplementOutput(taskID)
+	prNumber := ""
+	if impl != nil && impl.DraftPRNumber > 0 {
+		prNumber = fmt.Sprintf("%d", impl.DraftPRNumber)
+	}
+
+	return &VerifyInput{
+		Issue:      *issue,
+		PRNumber:   prNumber,
+		Repository: issue.Repository,
 	}, nil
 }
 

--- a/internal/handoff/store.go
+++ b/internal/handoff/store.go
@@ -128,6 +128,8 @@ func (s *Store) StorePhaseOutput(taskID string, phase Phase, iteration int, outp
 		hd.ReviewOutput = v
 	case *DocsOutput:
 		hd.DocsOutput = v
+	case *VerifyOutput:
+		hd.VerifyOutput = v
 	default:
 		return fmt.Errorf("unknown output type for phase %s: %T", phase, output)
 	}
@@ -189,6 +191,15 @@ func (s *Store) GetDocsOutput(taskID string) *DocsOutput {
 	return hd.DocsOutput
 }
 
+// GetVerifyOutput is a convenience method to get typed verify output.
+func (s *Store) GetVerifyOutput(taskID string) *VerifyOutput {
+	hd := s.GetPhaseOutput(taskID, PhaseVerify)
+	if hd == nil {
+		return nil
+	}
+	return hd.VerifyOutput
+}
+
 // ClearFromPhase clears all handoff data from the specified phase onwards.
 func (s *Store) ClearFromPhase(taskID string, phase Phase) {
 	s.mu.Lock()
@@ -203,6 +214,7 @@ func (s *Store) ClearFromPhase(taskID string, phase Phase) {
 		PhasePlan:      0,
 		PhaseImplement: 1,
 		PhaseDocs:      2,
+		PhaseVerify:    3,
 	}
 
 	targetOrder := phaseOrder[phase]

--- a/internal/handoff/types.go
+++ b/internal/handoff/types.go
@@ -12,6 +12,7 @@ const (
 	PhasePlan      Phase = "PLAN"
 	PhaseImplement Phase = "IMPLEMENT"
 	PhaseDocs      Phase = "DOCS"
+	PhaseVerify    Phase = "VERIFY"
 )
 
 // IssueContext contains the minimal context about the issue being worked on.
@@ -132,6 +133,26 @@ type DocsOutput struct {
 }
 
 // -----------------------------------------------------------------------------
+// VERIFY Phase
+// -----------------------------------------------------------------------------
+
+// VerifyInput is the curated input for the VERIFY phase.
+type VerifyInput struct {
+	Issue      IssueContext `json:"issue"`
+	PRNumber   string       `json:"pr_number"`
+	Repository string       `json:"repository"`
+}
+
+// VerifyOutput is the structured output from the VERIFY phase.
+type VerifyOutput struct {
+	ChecksPassed      bool     `json:"checks_passed"`
+	MergeSuccessful   bool     `json:"merge_successful"`
+	MergeSHA          string   `json:"merge_sha,omitempty"`
+	FailuresResolved  []string `json:"failures_resolved,omitempty"`
+	RemainingFailures []string `json:"remaining_failures,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
 // Handoff Envelope
 // -----------------------------------------------------------------------------
 
@@ -147,6 +168,7 @@ type HandoffData struct {
 	ImplementOutput *ImplementOutput `json:"implement_output,omitempty"`
 	ReviewOutput    *ReviewOutput    `json:"review_output,omitempty"`
 	DocsOutput      *DocsOutput      `json:"docs_output,omitempty"`
+	VerifyOutput    *VerifyOutput    `json:"verify_output,omitempty"`
 }
 
 // GetOutput returns the populated output based on the phase, or nil if none.
@@ -158,6 +180,8 @@ func (h *HandoffData) GetOutput() interface{} {
 		return h.ImplementOutput
 	case PhaseDocs:
 		return h.DocsOutput
+	case PhaseVerify:
+		return h.VerifyOutput
 	default:
 		return nil
 	}

--- a/internal/handoff/validator.go
+++ b/internal/handoff/validator.go
@@ -72,6 +72,14 @@ func (v *Validator) ValidatePhaseOutput(phase Phase, output interface{}) Validat
 		}
 		errs = append(errs, v.validateDocsOutput(out)...)
 
+	case PhaseVerify:
+		out, ok := output.(*VerifyOutput)
+		if !ok {
+			errs = append(errs, ValidationError{Phase: phase, Field: "type", Message: "expected *VerifyOutput"})
+			return errs
+		}
+		errs = append(errs, v.validateVerifyOutput(out)...)
+
 	default:
 		errs = append(errs, ValidationError{Phase: phase, Field: "phase", Message: "unknown phase"})
 	}
@@ -174,6 +182,21 @@ func (v *Validator) validateDocsOutput(out *DocsOutput) ValidationErrors {
 	return errs
 }
 
+// validateVerifyOutput validates VERIFY phase output.
+func (v *Validator) validateVerifyOutput(out *VerifyOutput) ValidationErrors {
+	var errs ValidationErrors
+
+	if out == nil {
+		errs = append(errs, ValidationError{Phase: PhaseVerify, Field: "output", Message: "output is nil"})
+		return errs
+	}
+
+	// VerifyOutput is valid as long as it's present - checks_passed and merge_successful
+	// are booleans that convey the result regardless of value
+
+	return errs
+}
+
 // ValidatePhaseInput validates that required inputs are present for a phase.
 func (v *Validator) ValidatePhaseInput(store *Store, taskID string, phase Phase) ValidationErrors {
 	var errs ValidationErrors
@@ -199,6 +222,11 @@ func (v *Validator) ValidatePhaseInput(store *Store, taskID string, phase Phase)
 		}
 		if store.GetImplementOutput(taskID) == nil {
 			errs = append(errs, ValidationError{Phase: phase, Field: "implement_output", Message: "implement output is required for DOCS phase"})
+		}
+
+	case PhaseVerify:
+		if store.GetImplementOutput(taskID) == nil {
+			errs = append(errs, ValidationError{Phase: phase, Field: "implement_output", Message: "implement output is required for VERIFY phase"})
 		}
 	}
 

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -78,6 +78,7 @@ type SessionConfig struct {
 	Delegation    *ProvDelegationConfig `json:"delegation,omitempty"`
 	PhaseLoop     *ProvPhaseLoopConfig  `json:"phase_loop,omitempty"`
 	Fallback      *ProvFallbackConfig   `json:"fallback,omitempty"`
+	AutoMerge     bool                  `json:"auto_merge,omitempty"`
 	Monorepo      *ProvMonorepoConfig   `json:"monorepo,omitempty"`
 }
 
@@ -103,6 +104,7 @@ type ProvPhaseLoopConfig struct {
 	ImplementMaxIterations int  `json:"implement_max_iterations,omitempty"`
 	ReviewMaxIterations    int  `json:"review_max_iterations,omitempty"`
 	DocsMaxIterations      int  `json:"docs_max_iterations,omitempty"`
+	VerifyMaxIterations    int  `json:"verify_max_iterations,omitempty"`
 	JudgeContextBudget     int  `json:"judge_context_budget,omitempty"`
 	JudgeNoSignalLimit     int  `json:"judge_no_signal_limit,omitempty"`
 }

--- a/internal/routing/types.go
+++ b/internal/routing/types.go
@@ -51,6 +51,10 @@ var ValidPhases = map[string]bool{
 	"PLAN_REVIEW":      true,
 	"IMPLEMENT_REVIEW": true,
 	"DOCS_REVIEW":      true,
+	// Compound phase keys for VERIFY
+	"VERIFY":        true,
+	"VERIFY_REVIEW": true,
+	"VERIFY_JUDGE":  true,
 	// Compound phase keys for judge
 	"JUDGE":           true,
 	"PLAN_JUDGE":      true,

--- a/prompts/skills/loader.go
+++ b/prompts/skills/loader.go
@@ -50,25 +50,33 @@ var embeddedCodeReviewer string
 //go:embed docs_reviewer.md
 var embeddedDocsReviewer string
 
+//go:embed verify.md
+var embeddedVerify string
+
+//go:embed verify_reviewer.md
+var embeddedVerifyReviewer string
+
 //go:embed judge.md
 var embeddedJudge string
 
 // skillFiles maps filenames to their embedded content.
 var skillFiles = map[string]string{
-	"scope.md":          embeddedScope,
-	"workflow.md":       embeddedWorkflow,
-	"safety.md":         embeddedSafety,
-	"environment.md":    embeddedEnvironment,
-	"status_signals.md": embeddedStatusSignals,
-	"plan.md":           embeddedPlan,
-	"implement.md":      embeddedImplement,
-	"test.md":           embeddedTest,
-	"pr_update.md":      embeddedPRUpdate,
-	"docs.md":           embeddedDocs,
-	"plan_reviewer.md":  embeddedPlanReviewer,
-	"code_reviewer.md":  embeddedCodeReviewer,
-	"docs_reviewer.md":  embeddedDocsReviewer,
-	"judge.md":          embeddedJudge,
+	"scope.md":           embeddedScope,
+	"workflow.md":        embeddedWorkflow,
+	"safety.md":          embeddedSafety,
+	"environment.md":     embeddedEnvironment,
+	"status_signals.md":  embeddedStatusSignals,
+	"plan.md":            embeddedPlan,
+	"implement.md":       embeddedImplement,
+	"test.md":            embeddedTest,
+	"pr_update.md":       embeddedPRUpdate,
+	"docs.md":            embeddedDocs,
+	"plan_reviewer.md":   embeddedPlanReviewer,
+	"code_reviewer.md":   embeddedCodeReviewer,
+	"docs_reviewer.md":   embeddedDocsReviewer,
+	"verify.md":          embeddedVerify,
+	"verify_reviewer.md": embeddedVerifyReviewer,
+	"judge.md":           embeddedJudge,
 }
 
 // LoadManifest parses the embedded manifest YAML.

--- a/prompts/skills/loader_test.go
+++ b/prompts/skills/loader_test.go
@@ -19,8 +19,8 @@ func TestLoadManifest(t *testing.T) {
 	expectedNames := []string{
 		"scope", "safety", "environment", "status_signals",
 		"plan", "implement", "test",
-		"pr_update", "docs",
-		"plan_reviewer", "code_reviewer", "docs_reviewer", "judge",
+		"pr_update", "docs", "verify",
+		"plan_reviewer", "code_reviewer", "docs_reviewer", "verify_reviewer", "judge",
 	}
 
 	names := make(map[string]bool)
@@ -46,18 +46,20 @@ func TestLoadManifest_Phases(t *testing.T) {
 		wantPhases []string
 	}{
 		{"scope", nil},
-		{"safety", []string{"PLAN", "IMPLEMENT", "DOCS", "PLAN_REVIEW", "IMPLEMENT_REVIEW", "DOCS_REVIEW"}},
+		{"safety", []string{"PLAN", "IMPLEMENT", "DOCS", "VERIFY", "PLAN_REVIEW", "IMPLEMENT_REVIEW", "DOCS_REVIEW", "VERIFY_REVIEW"}},
 		{"environment", nil},
 		{"status_signals", nil},
 		{"plan", []string{"PLAN"}},
 		{"implement", []string{"IMPLEMENT"}},
 		{"test", []string{"IMPLEMENT"}},
-		{"pr_update", []string{"DOCS", "IMPLEMENT_REVIEW", "DOCS_REVIEW"}},
+		{"pr_update", []string{"DOCS", "VERIFY", "IMPLEMENT_REVIEW", "DOCS_REVIEW", "VERIFY_REVIEW"}},
 		{"docs", []string{"DOCS"}},
 		{"plan_reviewer", []string{"PLAN_REVIEW"}},
 		{"code_reviewer", []string{"IMPLEMENT_REVIEW"}},
 		{"docs_reviewer", []string{"DOCS_REVIEW"}},
-		{"judge", []string{"JUDGE", "PLAN_JUDGE", "IMPLEMENT_JUDGE", "DOCS_JUDGE"}},
+		{"verify", []string{"VERIFY"}},
+		{"verify_reviewer", []string{"VERIFY_REVIEW"}},
+		{"judge", []string{"JUDGE", "PLAN_JUDGE", "IMPLEMENT_JUDGE", "DOCS_JUDGE", "VERIFY_JUDGE"}},
 	}
 
 	skillMap := make(map[string]SkillEntry)
@@ -147,19 +149,21 @@ func TestLoadSkills_ContentValidation(t *testing.T) {
 
 	// Spot-check that key content exists in expected skills
 	contentChecks := map[string]string{
-		"scope":          "SCOPE",
-		"safety":         "CRITICAL SAFETY CONSTRAINTS",
-		"environment":    "ENVIRONMENT",
-		"status_signals": "STATUS SIGNALING",
-		"plan":           "PLAN PHASE",
-		"implement":      "Pre-Flight Check",
-		"test":           "Development Loop",
-		"pr_update":      "PR Update Skill",
-		"docs":           "DOCS PHASE",
-		"plan_reviewer":  "PLAN REVIEWER",
-		"code_reviewer":  "CODE REVIEWER",
-		"docs_reviewer":  "DOCS REVIEWER",
-		"judge":          "JUDGE",
+		"scope":           "SCOPE",
+		"safety":          "CRITICAL SAFETY CONSTRAINTS",
+		"environment":     "ENVIRONMENT",
+		"status_signals":  "STATUS SIGNALING",
+		"plan":            "PLAN PHASE",
+		"implement":       "Pre-Flight Check",
+		"test":            "Development Loop",
+		"pr_update":       "PR Update Skill",
+		"docs":            "DOCS PHASE",
+		"verify":          "VERIFY PHASE",
+		"plan_reviewer":   "PLAN REVIEWER",
+		"code_reviewer":   "CODE REVIEWER",
+		"docs_reviewer":   "DOCS REVIEWER",
+		"verify_reviewer": "VERIFY REVIEWER",
+		"judge":           "JUDGE",
 	}
 
 	skillMap := make(map[string]Skill)

--- a/prompts/skills/manifest.yaml
+++ b/prompts/skills/manifest.yaml
@@ -16,9 +16,11 @@ skills:
       - PLAN
       - IMPLEMENT
       - DOCS
+      - VERIFY
       - PLAN_REVIEW
       - IMPLEMENT_REVIEW
       - DOCS_REVIEW
+      - VERIFY_REVIEW
 
   - name: environment
     file: environment.md
@@ -53,14 +55,22 @@ skills:
     priority: 70
     phases:
       - DOCS
+      - VERIFY
       - IMPLEMENT_REVIEW
       - DOCS_REVIEW
+      - VERIFY_REVIEW
 
   - name: docs
     file: docs.md
     priority: 77
     phases:
       - DOCS
+
+  - name: verify
+    file: verify.md
+    priority: 78
+    phases:
+      - VERIFY
 
   - name: plan_reviewer
     file: plan_reviewer.md
@@ -80,6 +90,12 @@ skills:
     phases:
       - DOCS_REVIEW
 
+  - name: verify_reviewer
+    file: verify_reviewer.md
+    priority: 93
+    phases:
+      - VERIFY_REVIEW
+
   - name: judge
     file: judge.md
     priority: 95
@@ -88,3 +104,4 @@ skills:
       - PLAN_JUDGE
       - IMPLEMENT_JUDGE
       - DOCS_JUDGE
+      - VERIFY_JUDGE

--- a/prompts/skills/verify.md
+++ b/prompts/skills/verify.md
@@ -1,0 +1,52 @@
+## VERIFY PHASE
+
+You are in the **VERIFY** phase. Your job is to verify that CI checks pass on the PR and merge it.
+
+### Steps
+
+1. Check CI status: `gh pr checks <PR_NUMBER> --repo <REPOSITORY>`
+2. If checks are **pending**, wait briefly and re-check (up to a few minutes)
+3. If checks **pass**: merge the PR with `gh pr merge <PR_NUMBER> --squash --delete-branch --repo <REPOSITORY>`
+4. If checks **fail**:
+   - Read the CI logs to identify the failure
+   - Diagnose the root cause
+   - Fix the code
+   - Commit and push the fix
+   - Re-check CI status after pushing
+
+### Rules
+
+- Use `gh pr checks` to monitor CI status — do NOT guess whether checks passed
+- If merge conflicts exist, rebase: `git pull --rebase origin main && git push --force-with-lease`
+- Only merge when ALL required checks pass
+- Use squash merge (`--squash`) to keep history clean
+- Always delete the branch after merge (`--delete-branch`)
+
+### Completion
+
+When verification is complete, emit a structured handoff signal:
+
+```
+AGENTIUM_HANDOFF: {
+  "checks_passed": true,
+  "merge_successful": true,
+  "merge_sha": "abc123",
+  "failures_resolved": ["lint: fixed unused import"],
+  "remaining_failures": []
+}
+```
+
+If checks fail and you cannot resolve them:
+```
+AGENTIUM_HANDOFF: {
+  "checks_passed": false,
+  "merge_successful": false,
+  "failures_resolved": [],
+  "remaining_failures": ["test: TestFoo times out"]
+}
+```
+
+Then emit:
+```
+AGENTIUM_STATUS: COMPLETE
+```

--- a/prompts/skills/verify_reviewer.md
+++ b/prompts/skills/verify_reviewer.md
@@ -1,0 +1,25 @@
+## VERIFY REVIEWER
+
+You are reviewing **CI verification and merge work** produced by an agent during the VERIFY phase. Your role is to provide constructive, actionable feedback on the verification work. You do NOT decide whether the work should advance or iterate — a separate judge will make that decision based on your feedback.
+
+### Evaluation Criteria
+
+- **CI Status:** Did the agent correctly check CI status using `gh pr checks`?
+- **Failure Diagnosis:** If checks failed, did the agent correctly identify the root cause?
+- **Fix Quality:** Were any fixes appropriate and minimal (not introducing new issues)?
+- **Merge Correctness:** Was the merge performed correctly (squash merge, branch deleted)?
+- **Completeness:** Were all required checks verified before attempting merge?
+
+### Guidelines
+
+- Be specific about which CI checks passed or failed
+- If the agent resolved failures, evaluate whether the fixes are correct
+- If checks are still pending, note that the agent should wait
+- Do NOT evaluate code quality of the original implementation — only fixes made during VERIFY
+- Focus on whether the merge is safe to proceed
+
+### Output
+
+**CRITICAL:** Do NOT include preamble or process descriptions. Start directly with your feedback. Do not begin with "Let me review...", "I'll examine...", or similar phrases.
+
+Provide your review feedback below. Be specific about what to improve.


### PR DESCRIPTION
## Summary

- Adds opt-in `--auto-merge` CLI flag that introduces a **VERIFY** phase after DOCS
- When enabled, the workflow becomes: PLAN → IMPLEMENT → DOCS → VERIFY → COMPLETE
- VERIFY marks the PR as ready for review, waits for CI checks to complete, and merges the PR on success
- On CI failure, the agent diagnoses issues, fixes code, pushes changes, and retries
- Without `--auto-merge`, behavior is unchanged (PR left as ready for human review)

### Changes across the stack
- **Config chain**: `AutoMerge` and `VerifyMaxIterations` fields added to CLI, config, provisioner, and controller
- **Phase loop**: Dynamic phase ordering via `phaseOrder()` method; `advancePhase` converted to controller method
- **Merge helpers**: `markPRReady()` and `attemptPRMerge()` in draft_pr.go
- **Handoff system**: Full VERIFY support (types, store, builders, parsers, validators)
- **Routing**: VERIFY, VERIFY_REVIEW, VERIFY_JUDGE added to valid phases
- **Skills**: New `verify.md` and `verify_reviewer.md` prompts; manifest updated with phase assignments
- **Tests**: Comprehensive coverage for phase ordering, merge helpers, handoff types, and skill loading

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `agentium run --help` shows `--auto-merge` flag
- [ ] Without `--auto-merge`: workflow unchanged (PLAN → IMPLEMENT → DOCS → COMPLETE)
- [ ] With `--auto-merge`: VERIFY phase runs after DOCS, CI checks evaluated, PR merged on success
- [ ] Edge case: VERIFY skipped when no PR exists
- [ ] Edge case: VERIFY skipped when NOMERGE flag set

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)