### PR TITLE
feat: Add BigQuery reporting module for token consumption

### DIFF
--- a/terraform/modules/reporting/gcp/README.md
+++ b/terraform/modules/reporting/gcp/README.md
@@ -1,0 +1,85 @@
+# Agentium Reporting Module (GCP)
+
+Terraform module that creates a Cloud Logging sink and BigQuery dataset for querying agentium token consumption across sessions.
+
+## Overview
+
+Agentium sessions log token usage to GCP Cloud Logging. This module routes those log entries into BigQuery and creates views for reporting on token consumption by issue, phase, agent, and model.
+
+**This is one-time project infrastructure.** Apply it once per GCP project — it persists across all agentium sessions.
+
+## Usage
+
+```hcl
+module "reporting" {
+  source     = "./terraform/modules/reporting/gcp"
+  project_id = "my-gcp-project"
+}
+```
+
+```bash
+terraform init
+terraform apply -var="project_id=my-gcp-project"
+```
+
+## Resources Created
+
+| Resource | Description |
+|----------|-------------|
+| `google_bigquery_dataset` | Dataset for token usage data (default: `agentium_reporting`) |
+| `google_logging_project_sink` | Routes `token_usage` log entries to BigQuery |
+| `google_bigquery_dataset_iam_member` | Grants the sink write access to the dataset |
+| 6x `google_bigquery_table` (views) | Reporting views (see below) |
+
+## Views
+
+| View | Groups By | Purpose |
+|------|-----------|---------|
+| `token_usage_flat` | (base view) | Flattens Cloud Logging labels into named columns |
+| `usage_by_issue` | `task_id` | Total tokens per issue across all phases |
+| `usage_by_phase` | `phase`, `agent` | Token breakdown by phase with avg/median/p95 stats |
+| `usage_by_worker` | `agent` | Token usage per agent adapter |
+| `usage_by_model` | `model` | Token usage per model |
+| `usage_combined` | `task_id` x `phase` x `agent` x `model` | Full pivot view |
+
+## Example Queries
+
+```sql
+-- Top 10 most expensive issues
+SELECT task_id, total_tokens, iterations
+FROM `my-project.agentium_reporting.usage_by_issue`
+ORDER BY total_tokens DESC
+LIMIT 10;
+
+-- Token usage by phase with p95
+SELECT phase, agent, iterations, total_tokens, avg_tokens, p95_tokens
+FROM `my-project.agentium_reporting.usage_by_phase`
+ORDER BY total_tokens DESC;
+
+-- Daily token spend
+SELECT
+  DATE(first_seen) AS day,
+  SUM(total_tokens) AS daily_tokens,
+  SUM(iterations) AS daily_iterations
+FROM `my-project.agentium_reporting.usage_combined`
+GROUP BY day
+ORDER BY day DESC;
+```
+
+## Variables
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `project_id` | GCP project ID | (required) |
+| `dataset_id` | BigQuery dataset ID | `agentium_reporting` |
+| `location` | BigQuery dataset location | `US` |
+| `log_name` | Cloud Logging log name | `agentium-session` |
+| `default_table_expiration_days` | Table expiration in days | `90` |
+| `sink_name` | Cloud Logging sink name | `agentium-token-usage-sink` |
+| `labels` | Labels for the BigQuery dataset | `{managed_by="terraform", purpose="agentium-reporting"}` |
+
+## Notes
+
+- The BigQuery table (`agentium_session`) is auto-created by Cloud Logging when the first matching log entry arrives. Views will return errors until then.
+- Cloud Logging stores labels as `REPEATED RECORD<key STRING, value STRING>`. All views use `UNNEST(labels)` to extract named columns.
+- Token counts are stored as strings in labels and converted via `SAFE_CAST` to `INT64`.

--- a/terraform/modules/reporting/gcp/main.tf
+++ b/terraform/modules/reporting/gcp/main.tf
@@ -1,0 +1,222 @@
+locals {
+  # Cloud Logging converts hyphens to underscores in auto-created BigQuery table names.
+  bigquery_table_name = replace(var.log_name, "-", "_")
+}
+
+# -----------------------------------------------------------------------------
+# BigQuery Dataset
+# -----------------------------------------------------------------------------
+
+resource "google_bigquery_dataset" "token_usage" {
+  project    = var.project_id
+  dataset_id = var.dataset_id
+  location   = var.location
+  labels     = var.labels
+
+  default_table_expiration_ms = var.default_table_expiration_days * 24 * 60 * 60 * 1000
+}
+
+# -----------------------------------------------------------------------------
+# Cloud Logging Sink → BigQuery
+# -----------------------------------------------------------------------------
+
+resource "google_logging_project_sink" "token_usage" {
+  project = var.project_id
+  name    = var.sink_name
+
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${google_bigquery_dataset.token_usage.dataset_id}"
+
+  filter = "logName = \"projects/${var.project_id}/logs/${var.log_name}\" AND labels.log_type = \"token_usage\""
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+# Grant the sink's writer identity permission to write to the dataset.
+resource "google_bigquery_dataset_iam_member" "sink_writer" {
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.token_usage.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = google_logging_project_sink.token_usage.writer_identity
+}
+
+# -----------------------------------------------------------------------------
+# BigQuery Views
+# -----------------------------------------------------------------------------
+
+# Base view: flattens the REPEATED RECORD labels column into named columns.
+resource "google_bigquery_table" "token_usage_flat" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.token_usage.dataset_id
+  table_id            = "token_usage_flat"
+  deletion_protection = false
+
+  view {
+    query = <<-SQL
+      SELECT
+        timestamp,
+        (SELECT value FROM UNNEST(labels) WHERE key = 'task_id')       AS task_id,
+        (SELECT value FROM UNNEST(labels) WHERE key = 'phase')         AS phase,
+        (SELECT value FROM UNNEST(labels) WHERE key = 'agent')         AS agent,
+        (SELECT value FROM UNNEST(labels) WHERE key = 'model')         AS model,
+        (SELECT value FROM UNNEST(labels) WHERE key = 'session_id')    AS session_id,
+        (SELECT value FROM UNNEST(labels) WHERE key = 'repository')    AS repository,
+        SAFE_CAST((SELECT value FROM UNNEST(labels) WHERE key = 'input_tokens')  AS INT64) AS input_tokens,
+        SAFE_CAST((SELECT value FROM UNNEST(labels) WHERE key = 'output_tokens') AS INT64) AS output_tokens,
+        SAFE_CAST((SELECT value FROM UNNEST(labels) WHERE key = 'total_tokens')  AS INT64) AS total_tokens
+      FROM
+        `${var.project_id}.${var.dataset_id}.${local.bigquery_table_name}`
+    SQL
+    use_legacy_sql = false
+  }
+
+  depends_on = [google_bigquery_dataset.token_usage]
+}
+
+# Usage by issue (task_id): total tokens per issue across all phases.
+resource "google_bigquery_table" "usage_by_issue" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.token_usage.dataset_id
+  table_id            = "usage_by_issue"
+  deletion_protection = false
+
+  view {
+    query = <<-SQL
+      SELECT
+        task_id,
+        COUNT(*)            AS iterations,
+        SUM(input_tokens)   AS total_input_tokens,
+        SUM(output_tokens)  AS total_output_tokens,
+        SUM(total_tokens)   AS total_tokens,
+        MIN(timestamp)      AS first_seen,
+        MAX(timestamp)      AS last_seen
+      FROM
+        `${var.project_id}.${var.dataset_id}.token_usage_flat`
+      GROUP BY
+        task_id
+    SQL
+    use_legacy_sql = false
+  }
+
+  depends_on = [google_bigquery_table.token_usage_flat]
+}
+
+# Usage by phase: token breakdown by phase and agent with statistics.
+resource "google_bigquery_table" "usage_by_phase" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.token_usage.dataset_id
+  table_id            = "usage_by_phase"
+  deletion_protection = false
+
+  view {
+    query = <<-SQL
+      SELECT
+        phase,
+        agent,
+        COUNT(*)                                                         AS iterations,
+        SUM(total_tokens)                                                AS total_tokens,
+        AVG(total_tokens)                                                AS avg_tokens,
+        APPROX_QUANTILES(total_tokens, 100)[OFFSET(50)]                 AS median_tokens,
+        APPROX_QUANTILES(total_tokens, 100)[OFFSET(95)]                 AS p95_tokens,
+        SUM(input_tokens)                                                AS total_input_tokens,
+        SUM(output_tokens)                                               AS total_output_tokens
+      FROM
+        `${var.project_id}.${var.dataset_id}.token_usage_flat`
+      GROUP BY
+        phase, agent
+    SQL
+    use_legacy_sql = false
+  }
+
+  depends_on = [google_bigquery_table.token_usage_flat]
+}
+
+# Usage by worker (agent adapter).
+resource "google_bigquery_table" "usage_by_worker" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.token_usage.dataset_id
+  table_id            = "usage_by_worker"
+  deletion_protection = false
+
+  view {
+    query = <<-SQL
+      SELECT
+        agent,
+        COUNT(*)            AS iterations,
+        SUM(input_tokens)   AS total_input_tokens,
+        SUM(output_tokens)  AS total_output_tokens,
+        SUM(total_tokens)   AS total_tokens,
+        AVG(total_tokens)   AS avg_tokens_per_iteration
+      FROM
+        `${var.project_id}.${var.dataset_id}.token_usage_flat`
+      GROUP BY
+        agent
+    SQL
+    use_legacy_sql = false
+  }
+
+  depends_on = [google_bigquery_table.token_usage_flat]
+}
+
+# Usage by model.
+resource "google_bigquery_table" "usage_by_model" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.token_usage.dataset_id
+  table_id            = "usage_by_model"
+  deletion_protection = false
+
+  view {
+    query = <<-SQL
+      SELECT
+        model,
+        COUNT(*)            AS iterations,
+        SUM(input_tokens)   AS total_input_tokens,
+        SUM(output_tokens)  AS total_output_tokens,
+        SUM(total_tokens)   AS total_tokens,
+        AVG(total_tokens)   AS avg_tokens_per_iteration
+      FROM
+        `${var.project_id}.${var.dataset_id}.token_usage_flat`
+      GROUP BY
+        model
+    SQL
+    use_legacy_sql = false
+  }
+
+  depends_on = [google_bigquery_table.token_usage_flat]
+}
+
+# Combined pivot view: full breakdown by task, phase, agent, and model.
+resource "google_bigquery_table" "usage_combined" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.token_usage.dataset_id
+  table_id            = "usage_combined"
+  deletion_protection = false
+
+  view {
+    query = <<-SQL
+      SELECT
+        task_id,
+        phase,
+        agent,
+        model,
+        session_id,
+        repository,
+        COUNT(*)            AS iterations,
+        SUM(input_tokens)   AS total_input_tokens,
+        SUM(output_tokens)  AS total_output_tokens,
+        SUM(total_tokens)   AS total_tokens,
+        MIN(timestamp)      AS first_seen,
+        MAX(timestamp)      AS last_seen
+      FROM
+        `${var.project_id}.${var.dataset_id}.token_usage_flat`
+      GROUP BY
+        task_id, phase, agent, model, session_id, repository
+    SQL
+    use_legacy_sql = false
+  }
+
+  depends_on = [google_bigquery_table.token_usage_flat]
+}

--- a/terraform/modules/reporting/gcp/outputs.tf
+++ b/terraform/modules/reporting/gcp/outputs.tf
@@ -1,0 +1,44 @@
+output "dataset_id" {
+  description = "The BigQuery dataset ID."
+  value       = google_bigquery_dataset.token_usage.dataset_id
+}
+
+output "sink_name" {
+  description = "The Cloud Logging sink name."
+  value       = google_logging_project_sink.token_usage.name
+}
+
+output "sink_writer_identity" {
+  description = "The service account identity used by the logging sink to write to BigQuery."
+  value       = google_logging_project_sink.token_usage.writer_identity
+}
+
+output "view_token_usage_flat" {
+  description = "Table ID of the token_usage_flat view."
+  value       = google_bigquery_table.token_usage_flat.table_id
+}
+
+output "view_usage_by_issue" {
+  description = "Table ID of the usage_by_issue view."
+  value       = google_bigquery_table.usage_by_issue.table_id
+}
+
+output "view_usage_by_phase" {
+  description = "Table ID of the usage_by_phase view."
+  value       = google_bigquery_table.usage_by_phase.table_id
+}
+
+output "view_usage_by_worker" {
+  description = "Table ID of the usage_by_worker view."
+  value       = google_bigquery_table.usage_by_worker.table_id
+}
+
+output "view_usage_by_model" {
+  description = "Table ID of the usage_by_model view."
+  value       = google_bigquery_table.usage_by_model.table_id
+}
+
+output "view_usage_combined" {
+  description = "Table ID of the usage_combined view."
+  value       = google_bigquery_table.usage_combined.table_id
+}

--- a/terraform/modules/reporting/gcp/variables.tf
+++ b/terraform/modules/reporting/gcp/variables.tf
@@ -1,0 +1,43 @@
+variable "project_id" {
+  description = "GCP project ID where Cloud Logging and BigQuery resources are created."
+  type        = string
+}
+
+variable "dataset_id" {
+  description = "BigQuery dataset ID for token usage reporting."
+  type        = string
+  default     = "agentium_reporting"
+}
+
+variable "location" {
+  description = "BigQuery dataset location."
+  type        = string
+  default     = "US"
+}
+
+variable "log_name" {
+  description = "Cloud Logging log name used by agentium sessions."
+  type        = string
+  default     = "agentium-session"
+}
+
+variable "default_table_expiration_days" {
+  description = "Default expiration in days for tables in the dataset."
+  type        = number
+  default     = 90
+}
+
+variable "sink_name" {
+  description = "Name of the Cloud Logging sink that routes token usage logs to BigQuery."
+  type        = string
+  default     = "agentium-token-usage-sink"
+}
+
+variable "labels" {
+  description = "Labels to apply to the BigQuery dataset."
+  type        = map(string)
+  default = {
+    managed_by = "terraform"
+    purpose    = "agentium-reporting"
+  }
+}

--- a/terraform/modules/reporting/gcp/versions.tf
+++ b/terraform/modules/reporting/gcp/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new Terraform module at `terraform/modules/reporting/gcp/` that creates Cloud Logging → BigQuery infrastructure for querying token consumption across agentium sessions
- Routes `token_usage` log entries from `agentium-session` Cloud Logging to a BigQuery dataset via a log sink with partitioned tables
- Creates 6 BigQuery views: `token_usage_flat` (base), `usage_by_issue`, `usage_by_phase` (with median/p95), `usage_by_worker`, `usage_by_model`, and `usage_combined` (full pivot)

## Details

This is **one-time project infrastructure** — applied once per GCP project via `terraform apply`, not embedded in the Go binary. The module reads from the existing token usage labels logged by `logTokenConsumption()` in `controller.go`.

### Resources created (9 total)
| Resource | Purpose |
|----------|---------|
| `google_bigquery_dataset` | Dataset `agentium_reporting` with 90-day default expiration |
| `google_logging_project_sink` | Routes matching logs to BigQuery |
| `google_bigquery_dataset_iam_member` | Grants sink write access |
| 6x `google_bigquery_table` (views) | Reporting views |

### Validation
- `terraform init` ✅
- `terraform validate` ✅
- `terraform plan -var="project_id=test-project"` — 9 resources to add ✅

## Test plan

- [ ] Run `terraform init && terraform validate` in `terraform/modules/reporting/gcp/`
- [ ] Run `terraform plan -var="project_id=<project>"` and verify 9 resources
- [ ] After applying: run an agentium session and verify log entries appear in BigQuery
- [ ] Query each view to confirm correct aggregation

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)