### PR TITLE
fix: Make reviewer dependency-aware to prevent false scope creep findings

### DIFF
--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1451,7 +1451,7 @@ func TestBuildIterateFeedbackSection(t *testing.T) {
 				c.memoryStore = store
 			}
 
-			got := c.buildIterateFeedbackSection(tt.taskID, tt.phaseIteration)
+			got := c.buildIterateFeedbackSection(tt.taskID, tt.phaseIteration, "")
 
 			if tt.wantEmpty {
 				if got != "" {

--- a/internal/controller/phase_loop.go
+++ b/internal/controller/phase_loop.go
@@ -555,6 +555,7 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 				PreviousFeedback:        previousFeedback,
 				WorkerHandoffSummary:    workerHandoffSummary,
 				WorkerFeedbackResponses: workerFeedbackResponses,
+				ParentBranch:            state.ParentBranch,
 			})
 			if reviewErr != nil {
 				c.logWarning("Reviewer error for phase %s: %v (defaulting to ADVANCE)", currentPhase, reviewErr)

--- a/prompts/skills/code_reviewer.md
+++ b/prompts/skills/code_reviewer.md
@@ -23,7 +23,7 @@ You are reviewing **code changes** produced by an agent during the REVIEW phase.
 - Distinguish between critical issues (would cause failures) and minor improvements (nice to have)
 - If the implementation looks good, say so briefly and note any minor improvements
 - Focus on functional correctness over style preferences
-- **Read the actual code changes** — do not rely solely on the phase output log. Run `git diff main..HEAD` to see what changed. Open key modified files to check surrounding context. The phase output shows agent activity, not a clean view of the code.
+- **Read the actual code changes** — do not rely solely on the phase output log. Use the `git diff` command specified in the review prompt to see what changed. Open key modified files to check surrounding context. The phase output shows agent activity, not a clean view of the code.
 - For significant architectural issues, recommend returning to the planning phase (REGRESS)
 - If you see changes that don't relate to the issue requirements, flag them explicitly
 - "Good code that wasn't asked for" is still a problem — it adds review burden and risk

--- a/prompts/skills/docs.md
+++ b/prompts/skills/docs.md
@@ -11,7 +11,7 @@ You are in the **DOCS** phase. Your job is to make MINIMAL documentation updates
 
 ### Steps
 
-1. Run `git diff main...HEAD` to see all changes
+1. Run `git diff` against the appropriate base branch to see all changes
 2. Check if existing documentation needs small updates (README, inline comments)
 3. Make minimal, targeted updates
 4. If no documentation updates are strictly necessary, that's fine — emit COMPLETE


### PR DESCRIPTION
Closes #415

## Summary

- When issue B depends on issue A, Agentium branches B from A's branch. The reviewer was always running `git diff main..HEAD`, which showed all of A's changes and flagged them as scope creep. The worker couldn't remove those commits without breaking the dependency chain, so all review iterations were wasted on an unfixable false positive.
- Now the reviewer diffs against the parent branch when one exists, and receives context explaining that inherited parent changes are expected.

## Changes

| File | Change |
|------|--------|
| `internal/controller/reviewer.go` | Add `ParentBranch` to `reviewRunParams`; use parent as diff base in `buildReviewPrompt()` with dependency context |
| `internal/controller/phase_loop.go` | Pass `state.ParentBranch` through to reviewer call site |
| `internal/controller/controller.go` | Update `buildIterateFeedbackSection()` to accept parent branch and use correct diff base for worker feedback |
| `internal/controller/reviewer_test.go` | Add `TestBuildReviewPrompt_ParentBranch`; verify no dependency context when no parent |
| `internal/controller/controller_test.go` | Update `buildIterateFeedbackSection` call sites for new signature |
| `prompts/skills/code_reviewer.md` | Replace hardcoded `git diff main..HEAD` with reference to dynamic prompt |
| `prompts/skills/docs.md` | Replace hardcoded `git diff main...HEAD` with generic instruction |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New `TestBuildReviewPrompt_ParentBranch` verifies parent branch diff and dependency context
- [x] Existing `TestBuildReviewPrompt` verifies `main` is still used when no parent branch
- [x] `golangci-lint run ./...` passes with 0 issues
- [ ] Deploy and verify on a batch with dependent issues (e.g. stillway issue chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)