### PR TITLE
feat: Add service_account_key support for GCP authentication

### DIFF
--- a/configs/example.agentium.yaml
+++ b/configs/example.agentium.yaml
@@ -22,6 +22,7 @@ cloud:
   machine_type: "e2-medium"         # VM instance type
   use_spot: true                    # Use spot/preemptible instances (cheaper)
   disk_size_gb: 50
+  # service_account_key: "~/.config/agentium/sa-key.json"  # GCP SA key file (optional)
 
 # Default session settings
 defaults:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,7 @@ cloud:
   machine_type: "e2-medium"         # VM instance type
   use_spot: true                    # Use spot/preemptible instances
   disk_size_gb: 50                  # Root disk size in GB
+  service_account_key: ""           # Path to GCP service account JSON key file (optional)
 
 # Default session settings
 defaults:
@@ -136,6 +137,7 @@ monorepo:
 | `machine_type` | string | No | `e2-medium` | VM instance type (see below) |
 | `use_spot` | bool | No | `false` | Use spot/preemptible instances for cost savings (recommended: set to `true` explicitly) |
 | `disk_size_gb` | int | No | `50` | Root disk size in GB |
+| `service_account_key` | string | No | - | Path to GCP service account JSON key file. When set, all Terraform and gcloud commands authenticate with this key instead of ambient credentials. See [GCP Service Account Authentication](cloud-setup/gcp.md#service-account-authentication). |
 
 **Machine type defaults by provider:**
 

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -64,7 +64,7 @@ func destroySession(cmd *cobra.Command, args []string) error {
 	}
 
 	verbose := viper.GetBool("verbose")
-	prov, err := provisioner.New(provider, verbose, cfg.Cloud.Project)
+	prov, err := provisioner.New(provider, verbose, cfg.Cloud.Project, cfg.Cloud.ServiceAccountKey)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -54,7 +54,7 @@ func getLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	verbose := viper.GetBool("verbose")
-	prov, err := provisioner.New(provider, verbose, cfg.Cloud.Project)
+	prov, err := provisioner.New(provider, verbose, cfg.Cloud.Project, cfg.Cloud.ServiceAccountKey)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -172,7 +172,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create provisioner
-	prov, err := provisioner.New(cfg.Cloud.Provider, verbose, cfg.Cloud.Project)
+	prov, err := provisioner.New(cfg.Cloud.Provider, verbose, cfg.Cloud.Project, cfg.Cloud.ServiceAccountKey)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -48,7 +48,7 @@ func checkStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	verbose := viper.GetBool("verbose")
-	prov, err := provisioner.New(provider, verbose, cfg.Cloud.Project)
+	prov, err := provisioner.New(provider, verbose, cfg.Cloud.Project, cfg.Cloud.ServiceAccountKey)
 	if err != nil {
 		return fmt.Errorf("failed to create provisioner: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,12 +84,13 @@ type GitHubConfig struct {
 
 // CloudConfig contains cloud provider settings
 type CloudConfig struct {
-	Provider    string `mapstructure:"provider"`
-	Region      string `mapstructure:"region"`
-	Project     string `mapstructure:"project"`      // GCP project ID
-	MachineType string `mapstructure:"machine_type"` // VM instance type
-	UseSpot     bool   `mapstructure:"use_spot"`     // Use spot/preemptible instances
-	DiskSizeGB  int    `mapstructure:"disk_size_gb"`
+	Provider          string `mapstructure:"provider"`
+	Region            string `mapstructure:"region"`
+	Project           string `mapstructure:"project"`      // GCP project ID
+	MachineType       string `mapstructure:"machine_type"` // VM instance type
+	UseSpot           bool   `mapstructure:"use_spot"`     // Use spot/preemptible instances
+	DiskSizeGB        int    `mapstructure:"disk_size_gb"`
+	ServiceAccountKey string `mapstructure:"service_account_key"` // Path to GCP service account JSON key file
 }
 
 // DefaultsConfig contains default session settings

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -172,11 +172,14 @@ type LogEntry struct {
 	ToolName  string // From labels.tool_name (e.g., "Bash", "Read")
 }
 
-// New creates a new provisioner for the specified cloud provider
-func New(provider string, verbose bool, project string) (Provisioner, error) {
+// New creates a new provisioner for the specified cloud provider.
+// The serviceAccountKey parameter is optional; when set to a path to a GCP
+// service account JSON key file, all terraform and gcloud commands will
+// authenticate using that key instead of ambient credentials.
+func New(provider string, verbose bool, project, serviceAccountKey string) (Provisioner, error) {
 	switch provider {
 	case "gcp":
-		return NewGCPProvisioner(verbose, project)
+		return NewGCPProvisioner(verbose, project, serviceAccountKey)
 	case "aws":
 		return nil, fmt.Errorf("AWS provisioner not yet implemented")
 	case "azure":

--- a/internal/provisioner/provisioner_test.go
+++ b/internal/provisioner/provisioner_test.go
@@ -46,7 +46,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prov, err := New(tt.provider, false, "test-project")
+			prov, err := New(tt.provider, false, "test-project", "")
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("New(%q) expected error, got nil", tt.provider)


### PR DESCRIPTION
## Summary
- Adds `service_account_key` config option to `CloudConfig` for explicit GCP service account authentication
- Sets `GOOGLE_APPLICATION_CREDENTIALS` (for Terraform) and `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` (for gcloud) on all provisioner commands when configured
- Handles `~` expansion in the key path
- Documents required IAM roles and adds step-by-step service account setup guide to GCP docs
- Updates configuration reference and example config

## Context
After transferring GCP project ownership, the user's personal account may lose IAM permissions needed by Terraform (e.g., `iam.serviceAccounts.create`, `compute.firewalls.create`). This feature allows authenticating with a dedicated service account key file instead of relying on ambient gcloud credentials.

## Usage
```yaml
cloud:
  provider: "gcp"
  project: "my-project"
  service_account_key: "~/.config/agentium/sa-key.json"
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 27 packages)
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] Manual test: configure `service_account_key` and run `agentium run` against GCP project

:robot: Generated with [Claude Code](https://claude.com/claude-code)