### PR TITLE
fix: Derive issue_url fallback and guard issue_number on task type

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -1281,13 +1281,15 @@ func (c *Controller) renderWithParameters(prompt string) string {
 		"repository": c.config.Repository,
 	}
 
-	// Add issue_url if available
+	// Add issue_url: prefer explicit PromptContext value, fall back to derived URL
 	if c.config.PromptContext != nil && c.config.PromptContext.IssueURL != "" {
 		builtins["issue_url"] = c.config.PromptContext.IssueURL
+	} else if c.activeTask != "" && c.activeTaskType == "issue" && c.config.Repository != "" {
+		builtins["issue_url"] = fmt.Sprintf("https://github.com/%s/issues/%s", c.config.Repository, c.activeTask)
 	}
 
-	// Add active task number if available
-	if c.activeTask != "" {
+	// Add issue_number only for issue tasks (not PR tasks)
+	if c.activeTask != "" && c.activeTaskType == "issue" {
 		builtins["issue_number"] = c.activeTask
 	}
 


### PR DESCRIPTION
## Summary
- When `PromptContext.IssueURL` is not provided, derive `issue_url` from `repository` + `activeTask` for issue-type tasks, preventing `{{issue_url}}` from silently staying unexpanded in prompts
- Guard `issue_number` builtin on `activeTaskType == "issue"` so PR task numbers are not incorrectly exposed as `issue_number`
- Add 7 test cases covering derivation, explicit override, PR task exclusion, and user parameter precedence

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 7 new `TestRenderWithParameters` cases pass)
- [x] `golangci-lint run ./...` — 0 issues

Closes #428
Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)