### PR TITLE
fix: correct BigQuery labels schema and surface gcloud stderr in logs command

### DIFF
--- a/internal/provisioner/gcp.go
+++ b/internal/provisioner/gcp.go
@@ -521,7 +521,11 @@ func (p *GCPProvisioner) Logs(ctx context.Context, sessionID string, opts LogsOp
 			p.setCredentialEnv(cmd)
 			output, err := cmd.Output()
 			if err != nil {
-				errCh <- fmt.Errorf("failed to read logs: %w", err)
+				if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
+					errCh <- fmt.Errorf("failed to read logs: %s", strings.TrimSpace(string(exitErr.Stderr)))
+				} else {
+					errCh <- fmt.Errorf("failed to read logs: %w", err)
+				}
 				return
 			}
 

--- a/terraform/modules/reporting/gcp/README.md
+++ b/terraform/modules/reporting/gcp/README.md
@@ -81,5 +81,5 @@ ORDER BY day DESC;
 ## Notes
 
 - The BigQuery table (`agentium_session`) is auto-created by Cloud Logging when the first matching log entry arrives. Views will return errors until then.
-- Cloud Logging stores labels as `REPEATED RECORD<key STRING, value STRING>`. All views use `UNNEST(labels)` to extract named columns.
+- Cloud Logging exports labels as a `NULLABLE RECORD` where each label key becomes a named column (e.g., `labels.session_id`). Views reference these fields directly via dot-notation.
 - Token counts are stored as strings in labels and converted via `SAFE_CAST` to `INT64`.


### PR DESCRIPTION
## Summary

- **BigQuery schema fix**: Changed the `labels` column in the base table from `REPEATED RECORD` (generic key/value) to `NULLABLE RECORD` with named fields matching the actual label keys emitted by the controller. Cloud Logging exports labels as a flat record with named columns, not an array of key/value pairs — the previous schema caused `table_invalid_schema` errors on the `agentium-token-usage-sink`, preventing any token usage data from reaching BigQuery.
- **View SQL update**: Simplified the `token_usage_flat` view to use dot-notation (`labels.task_id`) instead of `UNNEST(labels)` subqueries, matching the corrected schema.
- **Logs error reporting**: `agentium logs` now extracts stderr from `exec.ExitError` so gcloud errors are surfaced instead of the opaque "exit status 1".

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Run `terraform plan` on the reporting module to verify expected schema changes
- [ ] Run `agentium logs <session-id>` with an invalid/expired session to confirm the actual gcloud error is now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)