### PR TITLE
Bump default VM to e2-standard-2 and add dynamic Docker memory limits

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,7 +155,7 @@ func applyDefaults(cfg *Config) {
 	if cfg.Cloud.MachineType == "" {
 		switch cfg.Cloud.Provider {
 		case "gcp":
-			cfg.Cloud.MachineType = "e2-medium"
+			cfg.Cloud.MachineType = "e2-standard-2"
 		case "aws":
 			cfg.Cloud.MachineType = "t3.medium"
 		case "azure":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -372,7 +372,7 @@ func TestApplyDefaults(t *testing.T) {
 			expected: Config{
 				Cloud: CloudConfig{
 					Provider:    "gcp",
-					MachineType: "e2-medium",
+					MachineType: "e2-standard-2",
 					DiskSizeGB:  50,
 				},
 				Defaults: DefaultsConfig{
@@ -502,7 +502,7 @@ func TestApplyDefaults(t *testing.T) {
 				},
 				Cloud: CloudConfig{
 					Provider:    "gcp",
-					MachineType: "e2-medium",
+					MachineType: "e2-standard-2",
 					DiskSizeGB:  50,
 				},
 				Defaults: DefaultsConfig{

--- a/internal/controller/docker.go
+++ b/internal/controller/docker.go
@@ -49,6 +49,12 @@ func (c *Controller) runAgentContainer(ctx context.Context, params containerRunP
 		"-w", "/workspace",
 	}
 
+	// Apply memory limit if computed at startup
+	if c.containerMemLimit > 0 {
+		limit := fmt.Sprintf("%d", c.containerMemLimit)
+		args = append(args, "--memory", limit, "--memory-swap", limit)
+	}
+
 	// Add -i flag when piping stdin (keeps stdin open for prompt delivery)
 	if params.StdinPrompt != "" {
 		args = append(args, "-i")
@@ -88,7 +94,7 @@ func (c *Controller) runAgentContainer(ctx context.Context, params containerRunP
 	args = append(args, params.Agent.ContainerImage())
 	args = append(args, params.Command...)
 
-	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd := c.execCommand(ctx, "docker", args...)
 
 	// Pipe prompt via stdin if provided (for non-interactive mode)
 	if params.StdinPrompt != "" {

--- a/internal/provisioner/provisioner_test.go
+++ b/internal/provisioner/provisioner_test.go
@@ -71,7 +71,7 @@ func TestNew(t *testing.T) {
 func TestVMConfig(t *testing.T) {
 	config := VMConfig{
 		Region:      "us-central1",
-		MachineType: "e2-medium",
+		MachineType: "e2-standard-2",
 		UseSpot:     true,
 		DiskSizeGB:  50,
 		Session: SessionConfig{
@@ -95,8 +95,8 @@ func TestVMConfig(t *testing.T) {
 	if config.Region != "us-central1" {
 		t.Errorf("Region = %q, want %q", config.Region, "us-central1")
 	}
-	if config.MachineType != "e2-medium" {
-		t.Errorf("MachineType = %q, want %q", config.MachineType, "e2-medium")
+	if config.MachineType != "e2-standard-2" {
+		t.Errorf("MachineType = %q, want %q", config.MachineType, "e2-standard-2")
 	}
 	if !config.UseSpot {
 		t.Error("UseSpot = false, want true")

--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -23,7 +23,7 @@ variable "zone" {
 variable "machine_type" {
   description = "GCP machine type"
   type        = string
-  default     = "e2-medium"
+  default     = "e2-standard-2"
 }
 
 variable "use_spot" {


### PR DESCRIPTION
## Summary
- Bumps default GCP machine type from `e2-medium` (4GB) to `e2-standard-2` (8GB) to prevent OOM thrashing during IMPLEMENT phases
- Adds dynamic Docker `--memory` and `--memory-swap` limits derived from `/proc/meminfo` at startup, reserving 1GB for OS/Docker/controller
- Makes `runAgentContainer` use `c.execCommand` for testability via the existing `cmdRunner` mock pattern

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New tests `TestRunAgentContainer_MemoryLimit` and `TestRunAgentContainer_NoMemoryLimit` verify flag injection
- [x] Config and provisioner test assertions updated for `e2-standard-2`
- [ ] Deploy to staging VM and verify memory limit appears in controller logs

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)