### PR TITLE
Remove arbitrary 1000-character issue body truncation

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -53,15 +53,6 @@ const (
 	// AgentiumGID is the group ID for the agentium group in agent containers.
 	// This must match the GID in the agent Dockerfiles (defaults to same as UID).
 	AgentiumGID = 1000
-
-	// MaxReviewBodyLen is the maximum length for review body text before truncation.
-	MaxReviewBodyLen = 500
-
-	// MaxCommentBodyLen is the maximum length for inline comment text before truncation.
-	MaxCommentBodyLen = 300
-
-	// MaxIssueBodyLen is the maximum length for issue body text before truncation.
-	MaxIssueBodyLen = 1000
 )
 
 // TaskPhase represents the current phase of a task in its lifecycle
@@ -1443,11 +1434,7 @@ func (c *Controller) buildPromptForTask(issueNumber string, existingWork *agent.
 	if issue != nil {
 		sb.WriteString(fmt.Sprintf("**Title:** %s\n\n", issue.Title))
 		if issue.Body != "" {
-			body := issue.Body
-			if len(body) > MaxIssueBodyLen {
-				body = body[:MaxIssueBodyLen] + "..."
-			}
-			sb.WriteString(fmt.Sprintf("**Description:**\n%s\n\n", body))
+			sb.WriteString(fmt.Sprintf("**Description:**\n%s\n\n", issue.Body))
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Remove `MaxIssueBodyLen` truncation in `buildPromptForTask()` that silently dropped context from longer issue bodies
- Remove unused `MaxReviewBodyLen` and `MaxCommentBodyLen` constants (dead code)
- Claude Code manages its own context window — no technical reason for the framework to impose a 1000-char limit

Closes #445

## Test plan

- [x] `go build ./...` passes — no dangling references to removed constants
- [x] `go test ./internal/controller/...` passes — existing `buildPromptForTask` tests still work
- [x] `golangci-lint run ./...` clean

## Future work

Issue #446 tracks fetching and summarizing issue comments for initial agent context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)