### PR TITLE
Remove session-level max iterations; improve run output

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -252,8 +252,6 @@ cloud:
   disk_size_gb: 50
 
 defaults:
-  agent: "claude-code"
-  max_iterations: 30
   max_duration: "2h"
 
 phase_loop:

--- a/configs/example.agentium.yaml
+++ b/configs/example.agentium.yaml
@@ -26,7 +26,6 @@ cloud:
 
 # Default session settings
 defaults:
-  max_iterations: 30                # Maximum iterations before termination
   max_duration: "2h"                # Maximum session duration
 
 # Phase routing - which adapter+model to use per phase

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,6 @@ cloud:
 
 # Default session settings
 defaults:
-  max_iterations: 30                # Maximum agent iterations per session
   max_duration: "2h"                # Maximum session duration (Go duration format)
 
 # Codex agent authentication
@@ -151,7 +150,6 @@ monorepo:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `max_iterations` | int | No | `30` | Max iterations before session termination |
 | `max_duration` | string | No | `2h` | Max session duration (Go duration: `30m`, `2h`, `4h`) |
 
 ### codex
@@ -335,9 +333,9 @@ Tracing is enabled automatically when both `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_S
 
 Session-level settings (repository, issues, agent, etc.) are derived at runtime from CLI flags and config file defaults. They are **not** intended to be set directly in the config file. Instead:
 
-- `--repo`, `--issues`, `--agent`, `--max-iterations`, `--max-duration` are passed as CLI flags to `agentium run`
+- `--repo`, `--issues`, `--agent`, `--max-duration` are passed as CLI flags to `agentium run`
 - If `--agent` is not provided, it falls back to `routing.default.adapter` (or `claude-code` if not configured)
-- `max_iterations` and `max_duration` fall back to values in the `defaults` section
+- `max_duration` falls back to the value in the `defaults` section
 - The `repository` field falls back to `project.repository` if `--repo` is not provided (though `--repo` is always required for `run`)
 
 ## Environment Variables
@@ -353,7 +351,6 @@ All configuration values can be set via environment variables with the `AGENTIUM
 | `AGENTIUM_CLOUD_PROVIDER` | `cloud.provider` |
 | `AGENTIUM_CLOUD_REGION` | `cloud.region` |
 | `AGENTIUM_CLOUD_PROJECT` | `cloud.project` |
-| `AGENTIUM_DEFAULTS_MAX_ITERATIONS` | `defaults.max_iterations` |
 | `AGENTIUM_DEFAULTS_MAX_DURATION` | `defaults.max_duration` |
 | `AGENTIUM_ROUTING_DEFAULT_ADAPTER` | `routing.default.adapter` |
 | `AGENTIUM_CLAUDE_AUTH_MODE` | `claude.auth_mode` |
@@ -437,7 +434,6 @@ cloud:
   disk_size_gb: 100
 
 defaults:
-  max_iterations: 50
   max_duration: "4h"
 
 claude:
@@ -474,7 +470,6 @@ cloud:
   disk_size_gb: 30
 
 defaults:
-  max_iterations: 20
   max_duration: "1h"
 
 routing:

--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -35,7 +35,6 @@ type Session struct {
 	PRs              []string // PR numbers for review sessions
 	WorkDir          string
 	GitHubToken      string
-	MaxIterations    int
 	MaxDuration      string
 	Prompt           string
 	Metadata         map[string]string

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -67,8 +67,7 @@ type projectConfig struct {
 		Region   string `yaml:"region"`
 	} `yaml:"cloud"`
 	Defaults struct {
-		MaxIterations int    `yaml:"max_iterations"`
-		MaxDuration   string `yaml:"max_duration"`
+		MaxDuration string `yaml:"max_duration"`
 	} `yaml:"defaults"`
 	Routing struct {
 		Default struct {
@@ -156,7 +155,6 @@ func writeConfig(cmd *cobra.Command, configPath, cwd string) error {
 	}
 
 	cfg.GitHub.PrivateKeySecret = fmt.Sprintf("projects/YOUR_PROJECT/secrets/%s-github-key", cfg.Project.Name)
-	cfg.Defaults.MaxIterations = 30
 	cfg.Defaults.MaxDuration = "2h"
 	cfg.Routing.Default.Adapter = "claude-code"
 	cfg.Routing.Default.Model = "claude-sonnet-4-20250514"

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,7 +21,7 @@ It supports multiple AI agents (Claude Code, Aider, custom) and cloud providers
 that automatically terminates when tasks complete or limits are reached.
 
 Example:
-  agentium run --repo github.com/org/myapp --issues 12,17,24 --max-iterations 30`,
+  agentium run --repo github.com/org/myapp --issues 12,17,24`,
 }
 
 // Execute runs the root command

--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -54,10 +54,6 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	if agent := viper.GetString("session.agent"); agent != "" {
 		cfg.Session.Agent = agent
 	}
-	if cmd.Flags().Changed("max-iterations") {
-		maxIter, _ := cmd.Flags().GetInt("max-iterations")
-		cfg.Session.MaxIterations = maxIter
-	}
 	if cmd.Flags().Changed("max-duration") {
 		maxDur, _ := cmd.Flags().GetString("max-duration")
 		cfg.Session.MaxDuration = maxDur
@@ -102,7 +98,6 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	}
 	fmt.Printf("Agent: %s\n", cfg.Session.Agent)
 	fmt.Printf("Workspace: %s\n", workDir)
-	fmt.Printf("Max iterations: %d\n", cfg.Session.MaxIterations)
 	fmt.Printf("Max duration: %s\n", cfg.Session.MaxDuration)
 	if cfg.Session.AutoMerge {
 		fmt.Println("Auto-merge: enabled")
@@ -143,7 +138,6 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 		Repository:           cfg.Session.Repository,
 		Tasks:                cfg.Session.Tasks,
 		Agent:                cfg.Session.Agent,
-		MaxIterations:        cfg.Session.MaxIterations,
 		MaxDuration:          cfg.Session.MaxDuration,
 		Prompt:               cfg.Session.Prompt,
 		Interactive:          true, // Enable interactive mode

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -120,8 +120,8 @@ func showSessionStatus(ctx context.Context, cmd *cobra.Command, prov provisioner
 		} else if !status.StartTime.IsZero() {
 			fmt.Printf("Uptime: %s\n", time.Since(status.StartTime).Round(time.Second))
 		}
-		if status.MaxIterations > 0 {
-			fmt.Printf("Iteration: %d/%d\n", status.CurrentIteration, status.MaxIterations)
+		if status.CurrentIteration > 0 {
+			fmt.Printf("Iteration: %d\n", status.CurrentIteration)
 		}
 		if len(status.CompletedTasks) > 0 {
 			fmt.Printf("Completed tasks: %v\n", status.CompletedTasks)

--- a/internal/cloud/gcp/metadata.go
+++ b/internal/cloud/gcp/metadata.go
@@ -23,7 +23,6 @@ type MetadataUpdater interface {
 // instance metadata key. It matches the format parsed by the provisioner.
 type SessionStatusMetadata struct {
 	Iteration      int      `json:"iteration"`
-	MaxIterations  int      `json:"max_iterations"`
 	CompletedTasks []string `json:"completed_tasks"`
 	PendingTasks   []string `json:"pending_tasks"`
 }

--- a/internal/cloud/gcp/metadata_test.go
+++ b/internal/cloud/gcp/metadata_test.go
@@ -54,7 +54,6 @@ func TestComputeMetadataUpdater_UpdateStatus_AddsNewKey(t *testing.T) {
 
 	status := SessionStatusMetadata{
 		Iteration:      2,
-		MaxIterations:  5,
 		CompletedTasks: []string{"1"},
 		PendingTasks:   []string{"2", "3"},
 	}
@@ -93,9 +92,6 @@ func TestComputeMetadataUpdater_UpdateStatus_AddsNewKey(t *testing.T) {
 	if parsed.Iteration != 2 {
 		t.Errorf("expected iteration 2, got %d", parsed.Iteration)
 	}
-	if parsed.MaxIterations != 5 {
-		t.Errorf("expected max_iterations 5, got %d", parsed.MaxIterations)
-	}
 	if len(parsed.CompletedTasks) != 1 || parsed.CompletedTasks[0] != "1" {
 		t.Errorf("unexpected completed_tasks: %v", parsed.CompletedTasks)
 	}
@@ -105,7 +101,7 @@ func TestComputeMetadataUpdater_UpdateStatus_AddsNewKey(t *testing.T) {
 }
 
 func TestComputeMetadataUpdater_UpdateStatus_UpdatesExistingKey(t *testing.T) {
-	oldValue := `{"iteration":1,"max_iterations":5,"completed_tasks":[],"pending_tasks":["1","2"]}`
+	oldValue := `{"iteration":1,"completed_tasks":[],"pending_tasks":["1","2"]}`
 	mock := &mockMetadataAPI{
 		getInstance: func(ctx context.Context, project, zone, instance string) (*compute.Instance, error) {
 			return &compute.Instance{
@@ -126,7 +122,6 @@ func TestComputeMetadataUpdater_UpdateStatus_UpdatesExistingKey(t *testing.T) {
 
 	status := SessionStatusMetadata{
 		Iteration:      3,
-		MaxIterations:  5,
 		CompletedTasks: []string{"1", "2"},
 		PendingTasks:   []string{},
 	}
@@ -198,7 +193,7 @@ func TestComputeMetadataUpdater_UpdateStatus_SetMetadataError(t *testing.T) {
 
 	updater := NewComputeMetadataUpdaterWithAPI(mock, "test-project", "us-central1-a", "test-instance")
 
-	err := updater.UpdateStatus(context.Background(), SessionStatusMetadata{Iteration: 1, MaxIterations: 3})
+	err := updater.UpdateStatus(context.Background(), SessionStatusMetadata{Iteration: 1})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -223,7 +218,6 @@ func TestComputeMetadataUpdater_UpdateStatus_JSONFields(t *testing.T) {
 
 	status := SessionStatusMetadata{
 		Iteration:      4,
-		MaxIterations:  10,
 		CompletedTasks: []string{"issue:5", "pr:12"},
 		PendingTasks:   []string{"issue:7"},
 	}
@@ -240,7 +234,7 @@ func TestComputeMetadataUpdater_UpdateStatus_JSONFields(t *testing.T) {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 
-	expectedKeys := []string{"iteration", "max_iterations", "completed_tasks", "pending_tasks"}
+	expectedKeys := []string{"iteration", "completed_tasks", "pending_tasks"}
 	for _, key := range expectedKeys {
 		if _, ok := m[key]; !ok {
 			t.Errorf("missing expected JSON key %q", key)
@@ -249,9 +243,6 @@ func TestComputeMetadataUpdater_UpdateStatus_JSONFields(t *testing.T) {
 
 	if m["iteration"].(float64) != 4 {
 		t.Errorf("expected iteration 4, got %v", m["iteration"])
-	}
-	if m["max_iterations"].(float64) != 10 {
-		t.Errorf("expected max_iterations 10, got %v", m["max_iterations"])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,19 +100,17 @@ type CloudConfig struct {
 
 // DefaultsConfig contains default session settings
 type DefaultsConfig struct {
-	MaxIterations int    `mapstructure:"max_iterations"`
-	MaxDuration   string `mapstructure:"max_duration"`
+	MaxDuration string `mapstructure:"max_duration"`
 }
 
 // SessionConfig contains per-session settings
 type SessionConfig struct {
-	Repository    string   `mapstructure:"repository"`
-	Tasks         []string `mapstructure:"tasks"`
-	Agent         string   `mapstructure:"agent"`
-	MaxIterations int      `mapstructure:"max_iterations"`
-	MaxDuration   string   `mapstructure:"max_duration"`
-	Prompt        string   `mapstructure:"prompt"`
-	AutoMerge     bool     `mapstructure:"auto_merge"`
+	Repository  string   `mapstructure:"repository"`
+	Tasks       []string `mapstructure:"tasks"`
+	Agent       string   `mapstructure:"agent"`
+	MaxDuration string   `mapstructure:"max_duration"`
+	Prompt      string   `mapstructure:"prompt"`
+	AutoMerge   bool     `mapstructure:"auto_merge"`
 }
 
 // ControllerConfig contains session controller settings
@@ -167,10 +165,6 @@ func applyDefaults(cfg *Config) {
 		cfg.Cloud.DiskSizeGB = 50
 	}
 
-	if cfg.Defaults.MaxIterations == 0 {
-		cfg.Defaults.MaxIterations = 30
-	}
-
 	if cfg.Defaults.MaxDuration == "" {
 		cfg.Defaults.MaxDuration = "2h"
 	}
@@ -186,10 +180,6 @@ func applyDefaults(cfg *Config) {
 		} else {
 			cfg.Session.Agent = "claude-code"
 		}
-	}
-
-	if cfg.Session.MaxIterations == 0 {
-		cfg.Session.MaxIterations = cfg.Defaults.MaxIterations
 	}
 
 	if cfg.Session.MaxDuration == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -376,13 +376,11 @@ func TestApplyDefaults(t *testing.T) {
 					DiskSizeGB:  50,
 				},
 				Defaults: DefaultsConfig{
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					MaxDuration: "2h",
 				},
 				Session: SessionConfig{
-					Agent:         "claude-code",
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					Agent:       "claude-code",
+					MaxDuration: "2h",
 				},
 				Controller: ControllerConfig{
 					Image: "ghcr.io/andymwolf/agentium-controller:latest",
@@ -403,13 +401,11 @@ func TestApplyDefaults(t *testing.T) {
 					DiskSizeGB:  50,
 				},
 				Defaults: DefaultsConfig{
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					MaxDuration: "2h",
 				},
 				Session: SessionConfig{
-					Agent:         "claude-code",
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					Agent:       "claude-code",
+					MaxDuration: "2h",
 				},
 				Controller: ControllerConfig{
 					Image: "ghcr.io/andymwolf/agentium-controller:latest",
@@ -430,13 +426,11 @@ func TestApplyDefaults(t *testing.T) {
 					DiskSizeGB:  50,
 				},
 				Defaults: DefaultsConfig{
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					MaxDuration: "2h",
 				},
 				Session: SessionConfig{
-					Agent:         "claude-code",
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					Agent:       "claude-code",
+					MaxDuration: "2h",
 				},
 				Controller: ControllerConfig{
 					Image: "ghcr.io/andymwolf/agentium-controller:latest",
@@ -452,8 +446,7 @@ func TestApplyDefaults(t *testing.T) {
 					DiskSizeGB:  100,
 				},
 				Defaults: DefaultsConfig{
-					MaxIterations: 50,
-					MaxDuration:   "4h",
+					MaxDuration: "4h",
 				},
 				Routing: routing.PhaseRouting{
 					Default: routing.ModelConfig{
@@ -468,8 +461,7 @@ func TestApplyDefaults(t *testing.T) {
 					DiskSizeGB:  100,
 				},
 				Defaults: DefaultsConfig{
-					MaxIterations: 50,
-					MaxDuration:   "4h",
+					MaxDuration: "4h",
 				},
 				Routing: routing.PhaseRouting{
 					Default: routing.ModelConfig{
@@ -477,9 +469,8 @@ func TestApplyDefaults(t *testing.T) {
 					},
 				},
 				Session: SessionConfig{
-					Agent:         "aider",
-					MaxIterations: 50,
-					MaxDuration:   "4h",
+					Agent:       "aider",
+					MaxDuration: "4h",
 				},
 				Controller: ControllerConfig{
 					Image: "ghcr.io/andymwolf/agentium-controller:latest",
@@ -506,14 +497,12 @@ func TestApplyDefaults(t *testing.T) {
 					DiskSizeGB:  50,
 				},
 				Defaults: DefaultsConfig{
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					MaxDuration: "2h",
 				},
 				Session: SessionConfig{
-					Repository:    "github.com/org/repo",
-					Agent:         "claude-code",
-					MaxIterations: 30,
-					MaxDuration:   "2h",
+					Repository:  "github.com/org/repo",
+					Agent:       "claude-code",
+					MaxDuration: "2h",
 				},
 				Controller: ControllerConfig{
 					Image: "ghcr.io/andymwolf/agentium-controller:latest",

--- a/internal/controller/complexity.go
+++ b/internal/controller/complexity.go
@@ -59,7 +59,6 @@ func (c *Controller) runComplexityAssessor(ctx context.Context, params complexit
 		Tasks:          c.config.Tasks,
 		WorkDir:        c.workDir,
 		GitHubToken:    c.gitHubToken,
-		MaxIterations:  1,
 		MaxDuration:    c.config.MaxDuration,
 		Prompt:         assessorPrompt,
 		Metadata:       make(map[string]string),

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -29,7 +29,6 @@ func TestLoadConfigFromEnv_EnvVar(t *testing.T) {
 				"repository": "github.com/org/repo",
 				"tasks": ["1", "2"],
 				"agent": "claude-code",
-				"max_iterations": 30,
 				"max_duration": "2h"
 			}`,
 			wantID:    "test-session",
@@ -228,7 +227,6 @@ func TestLoadConfigFromEnv_FullConfig(t *testing.T) {
 		"repository": "github.com/org/repo",
 		"tasks": ["1", "2", "3"],
 		"agent": "claude-code",
-		"max_iterations": 50,
 		"max_duration": "4h",
 		"prompt": "Custom prompt here",
 		"github": {
@@ -264,9 +262,6 @@ func TestLoadConfigFromEnv_FullConfig(t *testing.T) {
 	}
 	if config.Agent != "claude-code" {
 		t.Errorf("Agent = %q, want %q", config.Agent, "claude-code")
-	}
-	if config.MaxIterations != 50 {
-		t.Errorf("MaxIterations = %d, want 50", config.MaxIterations)
 	}
 	if config.MaxDuration != "4h" {
 		t.Errorf("MaxDuration = %q, want %q", config.MaxDuration, "4h")
@@ -799,12 +794,11 @@ func TestNewController_RoutingAdapterInit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := SessionConfig{
-				ID:            "test-session",
-				Repository:    "github.com/org/repo",
-				Agent:         "claude-code",
-				MaxIterations: 10,
-				MaxDuration:   "1h",
-				Routing:       tt.routing,
+				ID:          "test-session",
+				Repository:  "github.com/org/repo",
+				Agent:       "claude-code",
+				MaxDuration: "1h",
+				Routing:     tt.routing,
 			}
 
 			c, err := New(config)

--- a/internal/controller/delegation.go
+++ b/internal/controller/delegation.go
@@ -56,7 +56,6 @@ func (c *Controller) runDelegatedIteration(ctx context.Context, phase TaskPhase,
 		Tasks:          c.config.Tasks,
 		WorkDir:        c.workDir,
 		GitHubToken:    c.gitHubToken,
-		MaxIterations:  c.config.MaxIterations,
 		MaxDuration:    c.config.MaxDuration,
 		Prompt:         prompt, // Use phase-aware prompt passed by caller
 		Metadata:       make(map[string]string),

--- a/internal/controller/judge.go
+++ b/internal/controller/judge.go
@@ -85,7 +85,6 @@ func (c *Controller) runJudge(ctx context.Context, params judgeRunParams) (Judge
 		Tasks:          c.config.Tasks,
 		WorkDir:        c.workDir,
 		GitHubToken:    c.gitHubToken,
-		MaxIterations:  1,
 		MaxDuration:    c.config.MaxDuration,
 		Prompt:         judgePrompt,
 		Metadata:       make(map[string]string),

--- a/internal/controller/reviewer.go
+++ b/internal/controller/reviewer.go
@@ -43,7 +43,6 @@ func (c *Controller) runReviewer(ctx context.Context, params reviewRunParams) (R
 		Tasks:          c.config.Tasks,
 		WorkDir:        c.workDir,
 		GitHubToken:    c.gitHubToken,
-		MaxIterations:  1,
 		MaxDuration:    c.config.MaxDuration,
 		Prompt:         reviewPrompt,
 		Metadata:       make(map[string]string),

--- a/internal/provisioner/gcp.go
+++ b/internal/provisioner/gcp.go
@@ -241,13 +241,11 @@ func (p *GCPProvisioner) List(ctx context.Context) ([]SessionStatus, error) {
 			if item.Key == "agentium-status" {
 				var sessionStatus struct {
 					Iteration      int      `json:"iteration"`
-					MaxIterations  int      `json:"max_iterations"`
 					CompletedTasks []string `json:"completed_tasks"`
 					PendingTasks   []string `json:"pending_tasks"`
 				}
 				if err := json.Unmarshal([]byte(item.Value), &sessionStatus); err == nil {
 					status.CurrentIteration = sessionStatus.Iteration
-					status.MaxIterations = sessionStatus.MaxIterations
 					status.CompletedTasks = sessionStatus.CompletedTasks
 					status.PendingTasks = sessionStatus.PendingTasks
 				}
@@ -370,13 +368,11 @@ func (p *GCPProvisioner) Status(ctx context.Context, sessionID string) (*Session
 		if item.Key == "agentium-status" {
 			var sessionStatus struct {
 				Iteration      int      `json:"iteration"`
-				MaxIterations  int      `json:"max_iterations"`
 				CompletedTasks []string `json:"completed_tasks"`
 				PendingTasks   []string `json:"pending_tasks"`
 			}
 			if err := json.Unmarshal([]byte(item.Value), &sessionStatus); err == nil {
 				status.CurrentIteration = sessionStatus.Iteration
-				status.MaxIterations = sessionStatus.MaxIterations
 				status.CompletedTasks = sessionStatus.CompletedTasks
 				status.PendingTasks = sessionStatus.PendingTasks
 			}

--- a/internal/provisioner/provisioner.go
+++ b/internal/provisioner/provisioner.go
@@ -73,7 +73,6 @@ type SessionConfig struct {
 	Repository    string                `json:"repository"`
 	Tasks         []string              `json:"tasks"`
 	Agent         string                `json:"agent"`
-	MaxIterations int                   `json:"max_iterations"`
 	MaxDuration   string                `json:"max_duration"`
 	Prompt        string                `json:"prompt"`
 	PromptContext *PromptContext        `json:"prompt_context,omitempty"` // Context for template variable substitution
@@ -153,7 +152,6 @@ type SessionStatus struct {
 	StartTime        time.Time
 	EndTime          time.Time
 	CurrentIteration int
-	MaxIterations    int
 	CompletedTasks   []string
 	PendingTasks     []string
 	LastError        string

--- a/internal/provisioner/provisioner_test.go
+++ b/internal/provisioner/provisioner_test.go
@@ -75,13 +75,12 @@ func TestVMConfig(t *testing.T) {
 		UseSpot:     true,
 		DiskSizeGB:  50,
 		Session: SessionConfig{
-			ID:            "test-session",
-			Repository:    "github.com/org/repo",
-			Tasks:         []string{"1", "2", "3"},
-			Agent:         "claude-code",
-			MaxIterations: 30,
-			MaxDuration:   "2h",
-			Prompt:        "Test prompt",
+			ID:          "test-session",
+			Repository:  "github.com/org/repo",
+			Tasks:       []string{"1", "2", "3"},
+			Agent:       "claude-code",
+			MaxDuration: "2h",
+			Prompt:      "Test prompt",
 			GitHub: GitHubConfig{
 				AppID:            123456,
 				InstallationID:   789012,
@@ -129,7 +128,6 @@ func TestSessionStatus(t *testing.T) {
 		StartTime:        now.Add(-1 * time.Hour),
 		EndTime:          time.Time{},
 		CurrentIteration: 5,
-		MaxIterations:    30,
 		CompletedTasks:   []string{"1", "2"},
 		PendingTasks:     []string{"3"},
 		LastError:        "",
@@ -158,9 +156,6 @@ func TestSessionStatus(t *testing.T) {
 	}
 	if status.CurrentIteration != 5 {
 		t.Errorf("CurrentIteration = %d, want 5", status.CurrentIteration)
-	}
-	if status.MaxIterations != 30 {
-		t.Errorf("MaxIterations = %d, want 30", status.MaxIterations)
 	}
 	if len(status.CompletedTasks) != 2 {
 		t.Errorf("len(CompletedTasks) = %d, want 2", len(status.CompletedTasks))


### PR DESCRIPTION
## Summary

- Remove the session-level `MaxIterations` (default 30) which was effectively dead code — each phase already has its own max iterations (plan=3, implement=5, docs=2, verify=3), so the global limit was never reached
- Improve `agentium run` startup output to show region, instance type, and multi-agent routing info when configured
- Simplify `agentium status` iteration display (show count only, not X/Y)

## Changes across 22 files

**Config** (`internal/config/`): Remove `MaxIterations` from `DefaultsConfig` and `SessionConfig` structs, remove default assignment and session fallback in `applyDefaults()`

**CLI** (`internal/cli/`): Remove `--max-iterations` flag, viper binding, CLI handler, and examples. Replace "Max iterations" output with Region/Instance/multi-agent display. Update `init.go` scaffolding.

**Controller** (`internal/controller/`): Remove `MaxIterations` from `SessionConfig`, remove iteration-count check from `shouldTerminate()` (time-limit and all-tasks-terminal checks remain), update metadata and final logs. Remove `MaxIterations` from agent Session literals in complexity.go, delegation.go, judge.go, reviewer.go.

**Provisioner** (`internal/provisioner/`): Remove `MaxIterations` from `SessionConfig` and `SessionStatus`. Update GCP metadata parsing.

**Cloud/Agent** (`internal/cloud/gcp/`, `internal/agent/`): Remove `MaxIterations` from `SessionStatusMetadata` and agent `Session` struct.

**Tests**: Update all affected test files (config, controller, provisioner, GCP metadata)

**Docs**: Update `docs/configuration.md`, `configs/example.agentium.yaml`, `ARCHITECTURE.md`

## What stays

- `c.iteration` counter (used for logging, observability, handoff store)
- Per-phase iteration limits (`PlanMaxIterations`, `ImplementMaxIterations`, etc.)
- `shouldTerminate()` with time-limit and all-tasks-terminal checks
- `SpanOptions.MaxIterations` in observability (already per-phase)

## Test plan

- [x] `go build ./...` — no compile errors
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — no lint errors
- [ ] Manual: `agentium run --help` should not show `--max-iterations`
- [ ] Manual: `agentium run` output should show Region, Instance, and proper agent info

🤖 Generated with [Claude Code](https://claude.com/claude-code)