### PR TITLE
fix: prevent branch contamination and PR mismatch between tasks

### DIFF
--- a/internal/controller/workspace_test.go
+++ b/internal/controller/workspace_test.go
@@ -92,6 +92,38 @@ func TestEnsureWorkspaceOwnership_EmptyDir(t *testing.T) {
 	}
 }
 
+func TestResetWorkspaceToMain_NonGitDir(t *testing.T) {
+	// resetWorkspaceToMain should warn but not panic when run in a non-git directory
+	tmpDir, err := os.MkdirTemp("", "workspace-reset-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ctrl := newTestController(tmpDir)
+
+	ctx := context.Background()
+
+	// Should not panic — just logs a warning
+	ctrl.resetWorkspaceToMain(ctx)
+}
+
+func TestResetWorkspaceToMain_ContextCanceled(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "workspace-reset-cancel-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ctrl := newTestController(tmpDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Should not panic — just logs a warning due to canceled context
+	ctrl.resetWorkspaceToMain(ctx)
+}
+
 func TestConfigureGitSafeDirectory(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "workspace-git-*")
 	if err != nil {

--- a/prompts/skills/safety.md
+++ b/prompts/skills/safety.md
@@ -31,6 +31,12 @@ These constraints are non-negotiable. Violating them will result in session term
 - Do NOT disable security features or linters
 - Run tests before creating a PR
 
+### 6. Issue Lifecycle
+- NEVER close or reopen GitHub issues directly (e.g., `gh issue close`, `gh issue reopen`)
+- The Agentium controller manages issue lifecycle based on PR merges and evaluation signals
+- Report completion status via `AGENTIUM_EVAL` or `AGENTIUM_STATUS` signals only
+- If an issue's acceptance criteria are already met, signal `AGENTIUM_STATUS: NOTHING_TO_DO` instead of closing
+
 ## PROHIBITED ACTIONS
 
 These actions are explicitly forbidden:
@@ -39,6 +45,7 @@ These actions are explicitly forbidden:
 - Force-pushing to any branch (`git push --force`)
 - Deleting remote branches
 - Modifying branch protection rules
+- Closing or reopening GitHub issues (`gh issue close`, `gh issue reopen`)
 - Accessing external services (except GitHub)
 - Installing system packages (`apt`, `brew`, etc.)
 - Modifying files outside `/workspace`


### PR DESCRIPTION
## Summary
- Add `resetWorkspaceToMain()` after each task's phase loop to prevent branch state leaking between tasks
- Validate PR branch ownership in `maybeCreateDraftPR` — skip adopting PRs whose branch belongs to a different issue
- Add explicit prohibition in agent safety prompt against closing GitHub issues directly (must use `AGENTIUM_STATUS` signals)

## Context
During a multi-task session, task N+1 would inherit task N's feature branch. This caused `maybeCreateDraftPR` to associate the wrong PR and VERIFY to merge the wrong PR. Additionally, the agent closed issue #363 directly via `gh issue close` without any code submission.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes (new tests for `resetWorkspaceToMain` and branch mismatch validation)
- [x] `golangci-lint run ./...` — 0 issues

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)