### PR TITLE
Fix BigQuery expense logging partitioning and schema

### DIFF
--- a/terraform/modules/reporting/gcp/README.md
+++ b/terraform/modules/reporting/gcp/README.md
@@ -80,6 +80,6 @@ ORDER BY day DESC;
 
 ## Notes
 
-- The BigQuery table (`agentium_session`) is auto-created by Cloud Logging when the first matching log entry arrives. Views will return errors until then.
+- The BigQuery table (`agentium_session`) is pre-created by Terraform so that views can reference it immediately. Cloud Logging extends the schema with additional columns (`insertId`, `resource`, `receiveTimestamp`, etc.) on the first matching log entry.
 - Cloud Logging exports labels as a `NULLABLE RECORD` where each label key becomes a named column (e.g., `labels.session_id`). Views reference these fields directly via dot-notation.
 - Token counts are stored as strings in labels and converted via `SAFE_CAST` to `INT64`.

--- a/terraform/modules/reporting/gcp/main.tf
+++ b/terraform/modules/reporting/gcp/main.tf
@@ -58,8 +58,7 @@ resource "google_bigquery_table" "log_entries" {
   deletion_protection = false
 
   time_partitioning {
-    type  = "DAY"
-    field = "timestamp"
+    type = "DAY"
   }
 
   schema = jsonencode([
@@ -74,9 +73,33 @@ resource "google_bigquery_table" "log_entries" {
       mode = "NULLABLE"
     },
     {
-      name = "textPayload"
-      type = "STRING"
+      name = "jsonPayload"
+      type = "RECORD"
       mode = "NULLABLE"
+      fields = [
+        { name = "timestamp", type = "STRING", mode = "NULLABLE" },
+        { name = "severity", type = "STRING", mode = "NULLABLE" },
+        { name = "message", type = "STRING", mode = "NULLABLE" },
+        { name = "session_id", type = "STRING", mode = "NULLABLE" },
+        { name = "iteration", type = "INTEGER", mode = "NULLABLE" },
+        {
+          name = "labels"
+          type = "RECORD"
+          mode = "NULLABLE"
+          fields = [
+            { name = "session_id", type = "STRING", mode = "NULLABLE" },
+            { name = "repository", type = "STRING", mode = "NULLABLE" },
+            { name = "log_type", type = "STRING", mode = "NULLABLE" },
+            { name = "task_id", type = "STRING", mode = "NULLABLE" },
+            { name = "phase", type = "STRING", mode = "NULLABLE" },
+            { name = "agent", type = "STRING", mode = "NULLABLE" },
+            { name = "model", type = "STRING", mode = "NULLABLE" },
+            { name = "input_tokens", type = "STRING", mode = "NULLABLE" },
+            { name = "output_tokens", type = "STRING", mode = "NULLABLE" },
+            { name = "total_tokens", type = "STRING", mode = "NULLABLE" }
+          ]
+        }
+      ]
     },
     {
       name = "logName"


### PR DESCRIPTION
## Summary

- **Fix table partitioning**: Remove `field = "timestamp"` from `time_partitioning` so the table uses ingestion-time partitioning (`_PARTITIONTIME`), matching what Cloud Logging sinks with `use_partitioned_tables = true` expect. The field-based partitioning was causing silent write failures.
- **Fix schema mismatch**: Replace `textPayload` (STRING) with `jsonPayload` (RECORD) containing nested fields matching the Go `LogEntry` struct. Cloud Logging stores struct payloads as `jsonPayload`, so the `textPayload` column was always NULL.
- **Fix README**: Correct note that incorrectly stated the table is auto-created by Cloud Logging — it is pre-created by Terraform.

## Test plan

- [ ] `go build ./...` passes (no Go changes, sanity check)
- [ ] `terraform validate` on the reporting module confirms valid HCL
- [ ] After applying: verify Cloud Logging entries appear in BigQuery via `SELECT * FROM agentium_reporting.token_usage_flat LIMIT 10`

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)