### PR TITLE
fix: add Langfuse Secret Manager config and diagnostic logging

### DIFF
--- a/configs/example.agentium.yaml
+++ b/configs/example.agentium.yaml
@@ -44,3 +44,19 @@ claude:
 # Controller settings (optional)
 controller:
   image: "ghcr.io/andymwolf/agentium-controller:latest"
+
+# Langfuse observability (optional)
+# Enables structured tracing of the phase loop (Worker/Reviewer/Judge) in Langfuse.
+#
+# Option A: Environment variables (local dev)
+#   export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+#   export LANGFUSE_SECRET_KEY="sk-lf-..."
+#
+# Option B: GCP Secret Manager (VM sessions)
+#   Store keys in Secret Manager and reference them below.
+#   See docs/langfuse-setup.md for setup instructions.
+#
+# langfuse:
+#   public_key_secret: "projects/my-gcp-project/secrets/langfuse-public-key/versions/latest"
+#   secret_key_secret: "projects/my-gcp-project/secrets/langfuse-secret-key/versions/latest"
+#   base_url: "https://cloud.langfuse.com"  # Only needed for self-hosted instances

--- a/internal/controller/logging.go
+++ b/internal/controller/logging.go
@@ -96,6 +96,8 @@ func (c *Controller) initTracer(ctx context.Context, logger *log.Logger) {
 		if pubPath == "" || secPath == "" {
 			if pubPath != secPath {
 				logger.Printf("Langfuse: incomplete config — both public_key_secret and secret_key_secret are required")
+			} else {
+				logger.Printf("Langfuse: not configured (no env vars or secret paths set, tracing disabled)")
 			}
 			return // No env vars and no secret paths configured
 		}


### PR DESCRIPTION
## Summary
- Add diagnostic log message in `initTracer()` when Langfuse is not configured (no env vars or Secret Manager paths), making it visible in controller logs why tracing is disabled on VM sessions
- Add commented-out `langfuse:` example to `configs/example.agentium.yaml` with instructions for both env vars (local dev) and Secret Manager (VM sessions)
- Update `docs/langfuse-setup.md` with GCP Secret Manager setup section (3b) and improved troubleshooting for the "no traces on VMs" pitfall

**Note:** `.agentium.yaml` (gitignored) also needs the `langfuse:` section added locally — see the docs for the required config.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] Create GCP Secret Manager secrets (`langfuse-public-key`, `langfuse-secret-key`)
- [ ] Add `langfuse:` section to `.agentium.yaml` with Secret Manager paths
- [ ] Run a session and verify controller logs show `Langfuse: tracer initialized` (not `not configured`)
- [ ] Verify traces appear in Langfuse dashboard

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)