### PR TITLE
fix: correct gofmt alignment in fallback_test.go

### DIFF
--- a/internal/controller/fallback_test.go
+++ b/internal/controller/fallback_test.go
@@ -274,8 +274,8 @@ type mockFallbackAgent struct {
 	name string
 }
 
-func (m *mockFallbackAgent) Name() string           { return m.name }
-func (m *mockFallbackAgent) ContainerImage() string    { return "test-image" }
+func (m *mockFallbackAgent) Name() string                  { return m.name }
+func (m *mockFallbackAgent) ContainerImage() string        { return "test-image" }
 func (m *mockFallbackAgent) ContainerEntrypoint() []string { return []string{"test-agent"} }
 func (m *mockFallbackAgent) BuildEnv(s *agent.Session, i int) map[string]string {
 	return nil


### PR DESCRIPTION
## Summary
- Fixes gofmt alignment in `fallback_test.go` that was causing CI lint failure after #470 merge

## Test plan
- [x] `gofmt -d` reports no diff
- [x] `go build ./...` passes
- [x] `go test ./...` passes