### PR TITLE
fix: harden reviewer against 'plan not on disk' confusion

### DIFF
--- a/internal/controller/reviewer.go
+++ b/internal/controller/reviewer.go
@@ -214,8 +214,9 @@ func (c *Controller) buildReviewPrompt(params reviewRunParams) string {
 	if params.CompletedPhase == PhasePlan {
 		// PLAN phase: no code changes exist — review the plan itself
 		sb.WriteString("Review the **plan** produced in this phase.\n\n")
-		sb.WriteString("**IMPORTANT:** Do NOT run `git diff` or look for modified files — there are none expected. ")
-		sb.WriteString("The PLAN phase produces a plan, not code.\n\n")
+		sb.WriteString("**IMPORTANT:** The plan is provided in the **Phase Output** section above — it is NOT written to a file on disk. ")
+		sb.WriteString("Do NOT run `git diff`, look for modified files, or search for plan files — there are none. ")
+		sb.WriteString("The PLAN phase produces a plan in the agent output, not code or files.\n\n")
 		sb.WriteString("Evaluate the plan on:\n")
 		sb.WriteString("- **Issue alignment:** Does the plan address what the issue asks for?\n")
 		sb.WriteString("- **Feasibility:** Is the approach technically sound?\n")

--- a/prompts/skills/plan_reviewer.md
+++ b/prompts/skills/plan_reviewer.md
@@ -12,6 +12,10 @@ You are reviewing a **plan** produced by an agent. Your role is to provide const
 
 Plans describe approach, not implementation code. Do not request code snippets, line numbers, or low-level details.
 
+### Where the Plan Is
+
+The plan is provided **inline in the phase output** included in your review prompt. It is NOT stored as a file on disk. Evaluate the plan as presented — do not look for plan files in the repository or workspace.
+
 ### Guidelines
 
 - Be specific about what needs improvement — vague feedback is unhelpful


### PR DESCRIPTION
## Summary

- Add "Where the Plan Is" section to `plan_reviewer.md` clarifying the plan is inline in the prompt, not a file
- Update PLAN phase instructions in `buildReviewPrompt()` to explicitly state the plan is in the Phase Output section

Closes #473

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run an agentium session with a PLAN phase and verify the reviewer no longer reports the plan as missing from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)