### PR TITLE
fix: systematic logging for Langfuse diagnostics and gcloud secret parsing

### DIFF
--- a/internal/controller/container_pool_test.go
+++ b/internal/controller/container_pool_test.go
@@ -81,7 +81,7 @@ func TestContainerPool_Start(t *testing.T) {
 	}
 
 	pool := NewContainerPool("/workspace", 0, "test-session-id", "IMPLEMENT",
-		poolMockCmdRunner(responses), newTestPoolLogger())
+		poolMockCmdRunner(responses), newTestPoolLogger(), nil)
 
 	id, err := pool.Start(context.Background(), RoleWorkerContainer, "test-image:latest",
 		[]string{"/runtime-scripts/agent-wrapper.sh", "claude"}, map[string]string{"FOO": "bar"}, nil)
@@ -111,7 +111,7 @@ func TestContainerPool_IsHealthy(t *testing.T) {
 	}
 
 	pool := NewContainerPool("/workspace", 0, "sess", "PLAN",
-		poolMockCmdRunner(responses), newTestPoolLogger())
+		poolMockCmdRunner(responses), newTestPoolLogger(), nil)
 
 	// Not started yet
 	if pool.IsHealthy(RoleWorkerContainer) {
@@ -141,7 +141,7 @@ func TestContainerPool_StopAll(t *testing.T) {
 	}
 
 	pool := NewContainerPool("/workspace", 0, "sess", "PLAN",
-		poolMockCmdRunner(responses), newTestPoolLogger())
+		poolMockCmdRunner(responses), newTestPoolLogger(), nil)
 
 	_, err := pool.Start(context.Background(), RoleWorkerContainer, "img", []string{"agent"}, nil, nil)
 	if err != nil {
@@ -164,7 +164,7 @@ func TestContainerPool_StopAll(t *testing.T) {
 
 func TestContainerPool_containerName(t *testing.T) {
 	pool := NewContainerPool("/workspace", 0, "abcdefghijklmnop", "IMPLEMENT",
-		nil, newTestPoolLogger())
+		nil, newTestPoolLogger(), nil)
 
 	name := pool.containerName(RoleWorkerContainer)
 	if !strings.HasPrefix(name, "agentium-") {
@@ -184,7 +184,7 @@ func TestContainerPool_containerName(t *testing.T) {
 
 func TestContainerPool_Exec_NoContainer(t *testing.T) {
 	pool := NewContainerPool("/workspace", 0, "sess", "PLAN",
-		nil, newTestPoolLogger())
+		nil, newTestPoolLogger(), nil)
 
 	_, _, _, err := pool.Exec(context.Background(), RoleWorkerContainer, []string{"echo"}, "", nil)
 	if err == nil {
@@ -199,7 +199,7 @@ func TestContainerPool_StartWithMemLimit(t *testing.T) {
 
 	memLimit := uint64(4 * 1024 * 1024 * 1024) // 4GB
 	pool := NewContainerPool("/workspace", memLimit, "sess", "PLAN",
-		poolMockCmdRunner(responses), newTestPoolLogger())
+		poolMockCmdRunner(responses), newTestPoolLogger(), nil)
 
 	id, err := pool.Start(context.Background(), RoleWorkerContainer, "img",
 		[]string{"agent"}, map[string]string{"KEY": "val"}, []string{"-v", "/tmp/claude/auth:/home/agentium/.claude/.credentials.json:ro"})
@@ -213,7 +213,7 @@ func TestContainerPool_StartWithMemLimit(t *testing.T) {
 
 func TestContainerPool_Start_EmptyEntrypoint(t *testing.T) {
 	pool := NewContainerPool("/workspace", 0, "sess", "PLAN",
-		poolMockCmdRunner(nil), newTestPoolLogger())
+		poolMockCmdRunner(nil), newTestPoolLogger(), nil)
 
 	_, err := pool.Start(context.Background(), RoleWorkerContainer, "img", nil, nil, nil)
 	if err == nil {
@@ -237,7 +237,7 @@ func TestContainerPool_Exec_PrependsEntrypoint(t *testing.T) {
 
 	var calls []capturedCall
 	pool := NewContainerPool("/workspace", 0, "sess", "PLAN",
-		poolCapturingCmdRunner(responses, &calls), newTestPoolLogger())
+		poolCapturingCmdRunner(responses, &calls), newTestPoolLogger(), nil)
 
 	entrypoint := []string{"/runtime-scripts/agent-wrapper.sh", "claude"}
 	_, err := pool.Start(context.Background(), RoleWorkerContainer, "img", entrypoint, nil, nil)

--- a/internal/controller/init_test.go
+++ b/internal/controller/init_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import "testing"
+
+func TestParseSecretName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "projects/my-project/secrets/langfuse-public-key/versions/latest",
+			want:  "langfuse-public-key",
+		},
+		{
+			input: "projects/my-project/secrets/langfuse-public-key",
+			want:  "langfuse-public-key",
+		},
+		{
+			input: "langfuse-public-key",
+			want:  "langfuse-public-key",
+		},
+		{
+			input: "projects/123/secrets/my-secret/versions/3",
+			want:  "my-secret",
+		},
+		{
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseSecretName(tt.input)
+			if got != tt.want {
+				t.Errorf("parseSecretName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/logging_test.go
+++ b/internal/controller/logging_test.go
@@ -103,6 +103,7 @@ func TestInitTracer(t *testing.T) {
 					BaseURL:         "https://custom.langfuse.com",
 				},
 			},
+			logger: logger,
 			secretManager: &mockSecretFetcher{
 				secrets: map[string]string{
 					"projects/p/secrets/langfuse-public": "  pk-lf-test  \n",
@@ -119,7 +120,7 @@ func TestInitTracer(t *testing.T) {
 		t.Setenv("LANGFUSE_BASE_URL", "")
 		t.Setenv("LANGFUSE_ENABLED", "")
 
-		c.initTracer(context.Background(), logger)
+		c.initTracer(context.Background())
 
 		// Verify tracer was initialized (not NoOp)
 		if _, ok := c.tracer.(*observability.NoOpTracer); ok {
@@ -150,6 +151,7 @@ func TestInitTracer(t *testing.T) {
 					SecretKeySecret: "projects/p/secrets/langfuse-secret",
 				},
 			},
+			logger:        logger,
 			secretManager: fetcher,
 			tracer:        &observability.NoOpTracer{},
 			shutdownCh:    make(chan struct{}),
@@ -160,7 +162,7 @@ func TestInitTracer(t *testing.T) {
 		t.Setenv("LANGFUSE_BASE_URL", "")
 		t.Setenv("LANGFUSE_ENABLED", "")
 
-		c.initTracer(context.Background(), logger)
+		c.initTracer(context.Background())
 
 		// Verify tracer was initialized from env vars
 		if _, ok := c.tracer.(*observability.NoOpTracer); ok {
@@ -191,7 +193,7 @@ func TestInitTracer(t *testing.T) {
 		t.Setenv("LANGFUSE_SECRET_KEY", "")
 		t.Setenv("LANGFUSE_ENABLED", "")
 
-		c.initTracer(context.Background(), logger)
+		c.initTracer(context.Background())
 
 		// Verify tracer stayed as NoOp
 		if _, ok := c.tracer.(*observability.NoOpTracer); !ok {
@@ -209,6 +211,7 @@ func TestInitTracer(t *testing.T) {
 
 		c := &Controller{
 			config:     SessionConfig{},
+			logger:     logger,
 			tracer:     &observability.NoOpTracer{},
 			shutdownCh: make(chan struct{}),
 		}
@@ -217,7 +220,7 @@ func TestInitTracer(t *testing.T) {
 		t.Setenv("LANGFUSE_SECRET_KEY", "")
 		t.Setenv("LANGFUSE_ENABLED", "")
 
-		c.initTracer(context.Background(), logger)
+		c.initTracer(context.Background())
 
 		if _, ok := c.tracer.(*observability.NoOpTracer); !ok {
 			t.Fatal("expected NoOpTracer when nothing is configured")
@@ -235,6 +238,7 @@ func TestInitTracer(t *testing.T) {
 					SecretKeySecret: "projects/p/secrets/langfuse-secret",
 				},
 			},
+			logger: logger,
 			secretManager: &mockSecretFetcher{
 				secrets: map[string]string{
 					"projects/p/secrets/langfuse-public": "pk-lf-test",
@@ -249,7 +253,7 @@ func TestInitTracer(t *testing.T) {
 		t.Setenv("LANGFUSE_SECRET_KEY", "")
 		t.Setenv("LANGFUSE_ENABLED", "false")
 
-		c.initTracer(context.Background(), logger)
+		c.initTracer(context.Background())
 
 		if _, ok := c.tracer.(*observability.NoOpTracer); !ok {
 			t.Fatal("expected NoOpTracer when LANGFUSE_ENABLED=false")

--- a/internal/controller/phase_loop.go
+++ b/internal/controller/phase_loop.go
@@ -1383,7 +1383,7 @@ func (c *Controller) phaseJudgeCriteria(phase TaskPhase) string {
 // with the correct adapter image, environment, and auth mounts based on
 // model routing configuration.
 func (c *Controller) startPhaseContainerPool(ctx context.Context, phase TaskPhase) {
-	pool := NewContainerPool(c.workDir, c.containerMemLimit, c.config.ID, string(phase), c.execCommand, c.logger)
+	pool := NewContainerPool(c.workDir, c.containerMemLimit, c.config.ID, string(phase), c.execCommand, c.logger, c.logWarning)
 
 	// Base session for building env
 	session := &agent.Session{

--- a/internal/observability/langfuse.go
+++ b/internal/observability/langfuse.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -335,7 +336,9 @@ func (t *LangfuseTracer) sendBatch(ctx context.Context, batch []ingestionEvent) 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("langfuse API returned %d", resp.StatusCode)
+		// Read response body (capped) for diagnostics
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("langfuse API returned %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Defer init warnings (Secret Manager, metadata updater) to post-Controller-construction so they route through `c.logWarning()` → Cloud Logging, making them visible via `agentium logs`
- Switch `initTracer()` from accepting `*log.Logger` to using `c.logInfo()`/`c.logWarning()`, with diagnostic logs for key source and secret paths being attempted
- Add `warnFn` callback to `ContainerPool` so pool warnings route to Cloud Logging when available
- Fix `filepath.Base()` bug in gcloud CLI fallback: `projects/P/secrets/NAME/versions/V` was incorrectly parsed as `V` instead of `NAME`; add `parseSecretName()` helper
- Include response body (capped at 512 bytes) in Langfuse `sendBatch()` HTTP errors for diagnosability

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/controller/ -v` — all existing + new tests pass
- [x] `go test ./internal/observability/ -v` — all tests pass
- [x] `go test ./...` — full suite passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Deploy to a test VM and verify Langfuse traces appear in `agentium logs`
- [ ] Verify gcloud fallback works with full secret paths (`projects/X/secrets/Y/versions/latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)