### PR TITLE
Add secret version update hint to langfuse setup guide

### DIFF
--- a/docs/langfuse-setup.md
+++ b/docs/langfuse-setup.md
@@ -66,6 +66,8 @@ echo -n "sk-lf-your-secret-key" | gcloud secrets create langfuse-secret-key \
   --project=YOUR_GCP_PROJECT --data-file=-
 ```
 
+or, if updating a pre-existing secret use `versions add` in place of `create`
+
 2. **Grant access** to the VM service account (if not already granted):
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a note about using `versions add` instead of `create` when updating a pre-existing GCP secret in the Langfuse setup docs

## Test plan

- [x] Documentation-only change, no code impact

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)