### PR TITLE
fix: add Langfuse response parsing and diagnostic logging

### DIFF
--- a/internal/controller/logging.go
+++ b/internal/controller/logging.go
@@ -141,4 +141,10 @@ func (c *Controller) initTracer(ctx context.Context) {
 		return c.tracer.Stop(ctx)
 	})
 	c.logInfo("Langfuse: tracer initialized (base_url=%s)", lt.BaseURL())
+
+	if err := lt.Ping(ctx); err != nil {
+		c.logWarning("Langfuse: connectivity check failed: %v", err)
+	} else {
+		c.logInfo("Langfuse: connectivity verified")
+	}
 }


### PR DESCRIPTION
## Summary

- **Parse ingestion API responses**: `sendBatch()` now reads and parses the response body on every 200/207 response, logging per-event rejections as warnings and a summary line with accepted/rejected counts. Previously the body was discarded, giving zero visibility into silently rejected events.
- **Add `Ping()` method**: Sends a minimal `trace-create` event at startup to verify API reachability and credential validity. Logged as info on success, warning on failure (tracer stays enabled so Langfuse can recover).
- **Add 6 new tests**: Response parsing (success, partial rejection, all rejected, malformed body) and Ping (success, auth failure).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/observability/... -v` — all 16 tests pass
- [x] `go test ./...` — full suite passes
- [x] `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)