### PR TITLE
fix: simplify BigQuery schema and add Cloud Logging error visibility

### DIFF
--- a/internal/cloud/gcp/logging.go
+++ b/internal/cloud/gcp/logging.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync/atomic"
 	"time"
 
@@ -118,6 +119,10 @@ func NewCloudLogger(ctx context.Context, cfg CloudLoggerConfig, opts ...option.C
 	client, err := logging.NewClient(ctx, cfg.ProjectID, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create logging client: %w", err)
+	}
+
+	client.OnError = func(err error) {
+		log.Printf("[cloud-logging] async delivery error: %v", err)
 	}
 
 	// Ping with retry to wait for IAM propagation. GCP IAM bindings can take

--- a/internal/controller/logging.go
+++ b/internal/controller/logging.go
@@ -72,6 +72,9 @@ func (c *Controller) logTokenConsumption(result *agent.IterationResult, agentNam
 		result.InputTokens, result.OutputTokens, result.InputTokens+result.OutputTokens)
 
 	c.cloudLogger.LogWithLabels(gcp.SeverityInfo, msg, labels)
+
+	c.logger.Printf("Cloud Logging: token_usage written (task=%s phase=%s tokens=%d)",
+		taskID, phase, result.InputTokens+result.OutputTokens)
 }
 
 // initTracer initializes the Langfuse observability tracer.

--- a/terraform/modules/reporting/gcp/main.tf
+++ b/terraform/modules/reporting/gcp/main.tf
@@ -62,54 +62,10 @@ resource "google_bigquery_table" "log_entries" {
   }
 
   schema = jsonencode([
+    { name = "timestamp", type = "TIMESTAMP", mode = "NULLABLE" },
+    { name = "logName", type = "STRING", mode = "NULLABLE" },
     {
-      name = "timestamp"
-      type = "TIMESTAMP"
-      mode = "NULLABLE"
-    },
-    {
-      name = "severity"
-      type = "STRING"
-      mode = "NULLABLE"
-    },
-    {
-      name = "jsonPayload"
-      type = "RECORD"
-      mode = "NULLABLE"
-      fields = [
-        { name = "timestamp", type = "STRING", mode = "NULLABLE" },
-        { name = "severity", type = "STRING", mode = "NULLABLE" },
-        { name = "message", type = "STRING", mode = "NULLABLE" },
-        { name = "session_id", type = "STRING", mode = "NULLABLE" },
-        { name = "iteration", type = "INTEGER", mode = "NULLABLE" },
-        {
-          name = "labels"
-          type = "RECORD"
-          mode = "NULLABLE"
-          fields = [
-            { name = "session_id", type = "STRING", mode = "NULLABLE" },
-            { name = "repository", type = "STRING", mode = "NULLABLE" },
-            { name = "log_type", type = "STRING", mode = "NULLABLE" },
-            { name = "task_id", type = "STRING", mode = "NULLABLE" },
-            { name = "phase", type = "STRING", mode = "NULLABLE" },
-            { name = "agent", type = "STRING", mode = "NULLABLE" },
-            { name = "model", type = "STRING", mode = "NULLABLE" },
-            { name = "input_tokens", type = "STRING", mode = "NULLABLE" },
-            { name = "output_tokens", type = "STRING", mode = "NULLABLE" },
-            { name = "total_tokens", type = "STRING", mode = "NULLABLE" }
-          ]
-        }
-      ]
-    },
-    {
-      name = "logName"
-      type = "STRING"
-      mode = "NULLABLE"
-    },
-    {
-      name = "labels"
-      type = "RECORD"
-      mode = "NULLABLE"
+      name = "labels", type = "RECORD", mode = "NULLABLE"
       fields = [
         { name = "session_id", type = "STRING", mode = "NULLABLE" },
         { name = "repository", type = "STRING", mode = "NULLABLE" },
@@ -124,6 +80,10 @@ resource "google_bigquery_table" "log_entries" {
       ]
     }
   ])
+
+  lifecycle {
+    ignore_changes = [schema]
+  }
 
   depends_on = [google_bigquery_dataset.token_usage]
 }


### PR DESCRIPTION
## Summary
- Simplified the placeholder BigQuery table schema by removing `jsonPayload` RECORD and `severity` column that conflicted with Cloud Logging's auto-detected schema
- Added `lifecycle { ignore_changes = [schema] }` to prevent Terraform from reverting Cloud Logging's schema extensions
- Added `OnError` handler to Cloud Logging client to surface async delivery errors
- Added diagnostic log for token consumption writes

## Context
Despite sessions running and Terraform applied, no data was appearing in BigQuery. The root cause was the overly detailed placeholder schema (especially `jsonPayload`) conflicting with Cloud Logging's serialization. Cloud Logging needs to add columns (`insertId`, `resource`, `receiveTimestamp`, etc.) that weren't in the placeholder.

## Post-merge ops steps
```bash
bq rm -f agentium-486616:agentium_reporting.agentium_session
cd terraform/modules/reporting/gcp && terraform apply -var="project_id=agentium-486616"
```

## Follow-up
- #499 — multi-project Terraform support

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] Delete existing BQ table + terraform apply on Stillway project
- [ ] Run a session and verify data appears in BigQuery

🤖 Generated with [Claude Code](https://claude.com/claude-code)