### PR TITLE
fix: parse token usage from top-level stream-json result event

### DIFF
--- a/internal/agent/claudecode/stream_test.go
+++ b/internal/agent/claudecode/stream_test.go
@@ -151,6 +151,25 @@ func TestParseStreamJSON_ResultWithTokens(t *testing.T) {
 	}
 }
 
+func TestParseStreamJSON_ResultWithTopLevelUsage(t *testing.T) {
+	// Current Claude Code format: usage and stop_reason at the top level, result is a plain string.
+	input := `{"type":"result","subtype":"success","is_error":false,"result":"4","stop_reason":"end_turn","usage":{"input_tokens":2,"output_tokens":5,"cache_creation_input_tokens":23101}}` + "\n"
+	result := ParseStreamJSON([]byte(input))
+
+	if result.TotalTokens == nil {
+		t.Fatal("expected non-nil TotalTokens")
+	}
+	if result.TotalTokens.InputTokens != 2 {
+		t.Errorf("InputTokens = %d, want %d", result.TotalTokens.InputTokens, 2)
+	}
+	if result.TotalTokens.OutputTokens != 5 {
+		t.Errorf("OutputTokens = %d, want %d", result.TotalTokens.OutputTokens, 5)
+	}
+	if result.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want %q", result.StopReason, "end_turn")
+	}
+}
+
 func TestParseStreamJSON_MalformedLineSkipped(t *testing.T) {
 	input := "not valid json\n" +
 		`{"type":"assistant","message":{"content":[{"type":"text","text":"valid"}]}}` + "\n" +


### PR DESCRIPTION
## Summary
- Fixed stream-json parser to extract `usage` and `stop_reason` from the top level of `result` events (current Claude Code 2.1.x format)
- Maintains backward compatibility with older format where these were nested inside the `result` object
- Added test covering the current format

## Root cause
Claude Code 2.1.x changed the stream-json result event structure:
- **Old**: `{"type":"result","result":{"content":[...],"usage":{...},"stop_reason":"..."}}`
- **Current**: `{"type":"result","result":"4","usage":{...},"stop_reason":"..."}`

The parser only checked `evt.Result` (old format). Since `result` is now a plain string, `json.Unmarshal` into `rawResult` failed silently, leaving `InputTokens` and `OutputTokens` at 0. `logTokenConsumption` then returned early on every iteration, so no `token_usage` entries were ever written to Cloud Logging.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] Existing test for old format still passes
- [x] New test for current format passes
- [ ] Deploy and verify `token_usage` entries appear in Cloud Logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)