### PR TITLE
fix: respect defaults.max_duration and defaults.agent from config file

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -55,8 +55,6 @@ func init() {
 
 	_ = viper.BindPFlag("session.repo", runCmd.Flags().Lookup("repo"))
 	_ = viper.BindPFlag("session.issues", runCmd.Flags().Lookup("issues"))
-	_ = viper.BindPFlag("session.agent", runCmd.Flags().Lookup("agent"))
-	_ = viper.BindPFlag("session.max_duration", runCmd.Flags().Lookup("max-duration"))
 	_ = viper.BindPFlag("cloud.provider", runCmd.Flags().Lookup("provider"))
 	_ = viper.BindPFlag("cloud.region", runCmd.Flags().Lookup("region"))
 	_ = viper.BindPFlag("claude.auth_mode", runCmd.Flags().Lookup("claude-auth-mode"))
@@ -99,7 +97,8 @@ func runSession(cmd *cobra.Command, args []string) error {
 		}
 		cfg.Session.Tasks = expandedIssues
 	}
-	if agent := viper.GetString("session.agent"); agent != "" {
+	if cmd.Flags().Changed("agent") {
+		agent, _ := cmd.Flags().GetString("agent")
 		cfg.Session.Agent = agent
 	}
 	if cmd.Flags().Changed("max-duration") {


### PR DESCRIPTION
## Summary
- Remove `viper.BindPFlag` for `session.agent` and `session.max_duration` flags, which caused flag defaults (`claude-code`, `2h`) to take priority over config file values during `viper.Unmarshal`
- Switch agent CLI override from `viper.GetString` to `cmd.Flags().Changed("agent")` pattern, consistent with `max-duration`
- Config file values like `defaults.max_duration: "6h"` now flow correctly through `applyDefaults()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [ ] `agentium run --issues 1 --dry-run` shows max duration from config file defaults
- [ ] `agentium run --issues 1 --max-duration 3h --dry-run` shows CLI override (3h)
- [ ] `agentium run --issues 1 --agent aider --dry-run` shows CLI override (aider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)