### PR TITLE
feat: add start/end times to Langfuse generation events

### DIFF
--- a/internal/agent/interface.go
+++ b/internal/agent/interface.go
@@ -1,5 +1,7 @@
 package agent
 
+import "time"
+
 // ExistingWork represents prior work detected on GitHub for a given issue
 type ExistingWork struct {
 	Branch   string // Existing remote branch name (e.g. "agentium/issue-6-cloud-logging")
@@ -68,6 +70,8 @@ type IterationResult struct {
 	AssistantText  string        `json:"-"` // Only assistant text blocks (for readable GitHub comments)
 	PromptInput    string        `json:"-"` // Prompt text sent to the LLM (for Langfuse generation input)
 	HandoffOutput  string        `json:"-"` // Raw AGENTIUM_HANDOFF JSON if present
+	StartTime      time.Time     `json:"-"` // When the LLM invocation started
+	EndTime        time.Time     `json:"-"` // When the LLM invocation finished
 }
 
 // Agent defines the interface that all agent adapters must implement

--- a/internal/controller/phase_loop.go
+++ b/internal/controller/phase_loop.go
@@ -593,6 +593,8 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 					InputTokens:  result.InputTokens,
 					OutputTokens: result.OutputTokens,
 					Status:       "completed",
+					StartTime:    result.StartTime,
+					EndTime:      result.EndTime,
 				})
 				totalInputTokens += result.InputTokens
 				totalOutputTokens += result.OutputTokens
@@ -817,6 +819,8 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 				InputTokens:  reviewResult.InputTokens,
 				OutputTokens: reviewResult.OutputTokens,
 				Status:       "completed",
+				StartTime:    reviewResult.StartTime,
+				EndTime:      reviewResult.EndTime,
 			})
 			totalInputTokens += reviewResult.InputTokens
 			totalOutputTokens += reviewResult.OutputTokens
@@ -873,6 +877,8 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 				InputTokens:  judgeResult.InputTokens,
 				OutputTokens: judgeResult.OutputTokens,
 				Status:       "completed",
+				StartTime:    judgeResult.StartTime,
+				EndTime:      judgeResult.EndTime,
 			})
 			totalInputTokens += judgeResult.InputTokens
 			totalOutputTokens += judgeResult.OutputTokens

--- a/internal/observability/langfuse.go
+++ b/internal/observability/langfuse.go
@@ -144,6 +144,14 @@ func (t *LangfuseTracer) StartPhase(trace TraceContext, phase string, opts SpanO
 
 // RecordGeneration records an LLM invocation as a Langfuse generation.
 func (t *LangfuseTracer) RecordGeneration(span SpanContext, gen GenerationInput) {
+	startTime := gen.StartTime
+	if startTime.IsZero() {
+		startTime = time.Now()
+	}
+	endTime := gen.EndTime
+	if endTime.IsZero() {
+		endTime = time.Now()
+	}
 	body := map[string]interface{}{
 		"id":                  uuid.New().String(),
 		"traceId":             span.TraceID,
@@ -155,10 +163,10 @@ func (t *LangfuseTracer) RecordGeneration(span SpanContext, gen GenerationInput)
 			"output": gen.OutputTokens,
 		},
 		"metadata": map[string]interface{}{
-			"status":      gen.Status,
-			"duration_ms": gen.DurationMs,
+			"status": gen.Status,
 		},
-		"startTime": time.Now().UTC().Format(time.RFC3339Nano),
+		"startTime": startTime.UTC().Format(time.RFC3339Nano),
+		"endTime":   endTime.UTC().Format(time.RFC3339Nano),
 	}
 	if gen.Input != "" {
 		body["input"] = gen.Input

--- a/internal/observability/tracer.go
+++ b/internal/observability/tracer.go
@@ -1,6 +1,9 @@
 package observability
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Tracer defines the interface for observability tracing.
 // Implementations track the lifecycle of tasks through phases,
@@ -60,8 +63,9 @@ type GenerationInput struct {
 	Output       string // Response text from the LLM
 	InputTokens  int
 	OutputTokens int
-	Status       string // "completed" or "error"
-	DurationMs   int64
+	Status       string    // "completed" or "error"
+	StartTime    time.Time // When the LLM invocation started
+	EndTime      time.Time // When the LLM invocation finished
 }
 
 // CompleteOptions configures trace completion.

--- a/internal/observability/tracer_test.go
+++ b/internal/observability/tracer_test.go
@@ -109,24 +109,30 @@ func TestLangfuseTracerSendsBatches(t *testing.T) {
 		MaxIterations: 5,
 	})
 
+	workerStart := time.Now().Add(-5 * time.Second)
+	workerEnd := time.Now()
 	tracer.RecordGeneration(span, GenerationInput{
 		Name:         "Worker",
 		Model:        "claude-sonnet-4-20250514",
 		InputTokens:  1500,
 		OutputTokens: 300,
 		Status:       "completed",
-		DurationMs:   5000,
+		StartTime:    workerStart,
+		EndTime:      workerEnd,
 	})
 
 	tracer.RecordSkipped(span, "Reviewer", "reviewer_skip=true")
 
+	judgeStart := time.Now().Add(-2 * time.Second)
+	judgeEnd := time.Now()
 	tracer.RecordGeneration(span, GenerationInput{
 		Name:         "Judge",
 		Model:        "claude-sonnet-4-20250514",
 		InputTokens:  800,
 		OutputTokens: 50,
 		Status:       "completed",
-		DurationMs:   2000,
+		StartTime:    judgeStart,
+		EndTime:      judgeEnd,
 	})
 
 	tracer.EndPhase(span, "completed", 7000)


### PR DESCRIPTION
## Summary

- Thread `StartTime`/`EndTime` through `IterationResult`, `ReviewResult`, and `JudgeResult` into Langfuse generation events so latency percentiles (p50/p90/p95/p99) are computed natively by Langfuse from `endTime - startTime`
- Replace hardcoded `time.Now()` `startTime` with real execution timestamps captured around container runs
- Remove `DurationMs` from `GenerationInput` and generation metadata since Langfuse computes duration from the timestamps directly

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes
- [ ] Deploy and verify Langfuse "Generation latency percentiles" dashboard shows p50/p90/p95/p99 values for Worker, Reviewer, and Judge

🤖 Generated with [Claude Code](https://claude.com/claude-code)