### PR TITLE
fix: align struct fields in EndPhaseOptions to satisfy gofmt

### DIFF
--- a/internal/observability/tracer.go
+++ b/internal/observability/tracer.go
@@ -59,8 +59,8 @@ type SpanOptions struct {
 type EndPhaseOptions struct {
 	Status     string
 	DurationMs int64
-	Input  any // JSON-serializable, may be nil
-	Output any // JSON-serializable, may be nil
+	Input      any // JSON-serializable, may be nil
+	Output     any // JSON-serializable, may be nil
 }
 
 // GenerationInput describes an LLM invocation to record.


### PR DESCRIPTION
## Summary
- Fix `gofmt` lint error in `internal/observability/tracer.go` by aligning `Input` and `Output` fields in `EndPhaseOptions` struct

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)