### PR TITLE
feat: use AssistantText for Worker and Judge Langfuse generation output

### DIFF
--- a/internal/controller/judge.go
+++ b/internal/controller/judge.go
@@ -197,7 +197,13 @@ func (c *Controller) runJudge(ctx context.Context, params judgeRunParams) (Judge
 	judgeResult := parseJudgeVerdict(parseSource)
 	judgeResult.Prompt = stdinPrompt
 	judgeResult.SystemPrompt = judgeSkillsPrompt
-	judgeResult.Output = parseSource
+	// Prefer AssistantText (excludes tool results like diffs/file contents),
+	// falling back to parseSource (RawTextContent) for adapters that don't populate it.
+	judgeOutput := result.AssistantText
+	if judgeOutput == "" {
+		judgeOutput = parseSource
+	}
+	judgeResult.Output = judgeOutput
 	judgeResult.InputTokens = result.InputTokens
 	judgeResult.OutputTokens = result.OutputTokens
 	judgeResult.StartTime = judgeStart


### PR DESCRIPTION
## Summary
- Prefer `AssistantText` over `RawTextContent` for Worker and Judge Langfuse generation Output fields, with fallback when `AssistantText` is empty
- Makes Langfuse traces cleaner by excluding tool results (diffs, file contents, command output) — showing only the assistant's own text
- Matches the pattern already used by the Reviewer (`reviewer.go:151-156`)
- Internal processing (handoff parsing, judge verdict parsing) continues to use full `RawTextContent`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] Verify Langfuse traces show cleaner Worker/Judge generation outputs in a live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)