### PR TITLE
fix: add AGENTIUM_EVAL verdict signal to reviewer prompts

### DIFF
--- a/prompts/skills/code_reviewer.md
+++ b/prompts/skills/code_reviewer.md
@@ -35,3 +35,20 @@ You are reviewing **code changes** produced by an agent during the REVIEW phase.
 Provide your review feedback below. Be specific about what to improve.
 
 For critical architectural issues that require re-planning, clearly state: "Recommend REGRESS to PLAN phase: <reason>"
+
+### Verdict Recommendation
+
+After your feedback, you MUST emit exactly one verdict recommendation line:
+
+```
+AGENTIUM_EVAL: ITERATE <brief summary of what needs fixing>
+```
+or
+```
+AGENTIUM_EVAL: ADVANCE
+```
+
+Recommend **ITERATE** when you identified any critical issues, functional bugs, or meaningful improvements the worker should address.
+Recommend **ADVANCE** when the work is solid or only has minor cosmetic issues that aren't worth another iteration.
+
+This is a recommendation — a separate judge makes the final decision.

--- a/prompts/skills/docs_reviewer.md
+++ b/prompts/skills/docs_reviewer.md
@@ -36,3 +36,20 @@ You are reviewing **documentation changes** produced by an agent during the DOCS
 Provide your review feedback below. Be specific about what to improve.
 
 For documentation that looks good or was correctly skipped, say so briefly.
+
+### Verdict Recommendation
+
+After your feedback, you MUST emit exactly one verdict recommendation line:
+
+```
+AGENTIUM_EVAL: ITERATE <brief summary of what needs fixing>
+```
+or
+```
+AGENTIUM_EVAL: ADVANCE
+```
+
+Recommend **ITERATE** when documentation has meaningful issues (inaccurate content, over-documentation, missing necessary docs).
+Recommend **ADVANCE** when docs are correct or only have minor issues, or when the agent correctly determined no docs were needed.
+
+This is a recommendation — a separate judge makes the final decision.

--- a/prompts/skills/judge.md
+++ b/prompts/skills/judge.md
@@ -11,11 +11,12 @@ You are the **judge**. Your role is to interpret the reviewer's feedback and dec
 **Step 2: Decide**
 
 **ADVANCE** when:
-- Feedback is positive or minor
+- Reviewer recommends ADVANCE, or feedback is positive/minor
 - Meaningful concerns are addressed
 - Work meets core requirements
 
 **ITERATE** when:
+- Reviewer recommends ITERATE with actionable feedback
 - Meaningful concerns are unaddressed
 - Critical functionality is missing
 - Scope creep must be removed
@@ -27,6 +28,9 @@ You are the **judge**. Your role is to interpret the reviewer's feedback and dec
 ### Iteration Awareness
 
 - On early iterations (1-2): Be strict. Require quality work before advancing.
+- When the reviewer recommends ITERATE, give significant weight to that recommendation,
+  especially on early iterations. Override a reviewer ITERATE only if you can specifically
+  explain why their concerns are invalid or already addressed in the current work.
 - On middle iterations: Balance quality with forward progress.
 - On final iterations: Prefer ADVANCE unless there are critical issues that would prevent the work from being usable. Diminishing returns from further iteration.
 

--- a/prompts/skills/plan_reviewer.md
+++ b/prompts/skills/plan_reviewer.md
@@ -32,3 +32,20 @@ The plan is provided **inline in the phase output** included in your review prom
 **CRITICAL:** Do NOT include preamble or process descriptions. Start directly with your feedback. Do not begin with "Let me review...", "I'll examine...", or similar phrases.
 
 Provide your review feedback below. Be specific about what to improve.
+
+### Verdict Recommendation
+
+After your feedback, you MUST emit exactly one verdict recommendation line:
+
+```
+AGENTIUM_EVAL: ITERATE <brief summary of what needs fixing>
+```
+or
+```
+AGENTIUM_EVAL: ADVANCE
+```
+
+Recommend **ITERATE** when you identified meaningful issues with the plan (missing steps, wrong approach, scope problems).
+Recommend **ADVANCE** when the plan is solid or only has minor issues.
+
+This is a recommendation — a separate judge makes the final decision.

--- a/prompts/skills/verify_reviewer.md
+++ b/prompts/skills/verify_reviewer.md
@@ -23,3 +23,20 @@ You are reviewing **CI verification and merge work** produced by an agent during
 **CRITICAL:** Do NOT include preamble or process descriptions. Start directly with your feedback. Do not begin with "Let me review...", "I'll examine...", or similar phrases.
 
 Provide your review feedback below. Be specific about what to improve.
+
+### Verdict Recommendation
+
+After your feedback, you MUST emit exactly one verdict recommendation line:
+
+```
+AGENTIUM_EVAL: ITERATE <brief summary of what needs fixing>
+```
+or
+```
+AGENTIUM_EVAL: ADVANCE
+```
+
+Recommend **ITERATE** when CI checks failed and fixes are needed, or the merge was incorrect.
+Recommend **ADVANCE** when verification passed and merge was successful or correctly deferred.
+
+This is a recommendation — a separate judge makes the final decision.


### PR DESCRIPTION
## Summary

- Add `### Verdict Recommendation` section to all four reviewer prompts (`code_reviewer.md`, `plan_reviewer.md`, `docs_reviewer.md`, `verify_reviewer.md`) requiring them to emit `AGENTIUM_EVAL: ITERATE` or `AGENTIUM_EVAL: ADVANCE` signals
- Strengthen the judge prompt to give significant weight to reviewer ITERATE recommendations on early iterations, and update the Decision Process to reference reviewer verdicts
- No Go code changes — the existing `extractReviewerVerdict()` and `JudgeOverrodeReviewer` logic already handle parsing and enforcement

**Root cause**: Reviewers never emitted `AGENTIUM_EVAL:` verdict recommendations, so the judge had no anchoring signal and rubber-stamped ADVANCE on iteration 1/5 despite substantial feedback. The `JudgeOverrodeReviewer` safety net was dead code.

## Test plan

- [x] `go build ./...` — passes (no Go changes)
- [x] `go test ./...` — passes (no Go changes)
- [ ] Grep reviewer prompts to confirm `AGENTIUM_EVAL:` signal is present in all four
- [ ] End-to-end: verify reviewer output contains `AGENTIUM_EVAL: ITERATE/ADVANCE`
- [ ] End-to-end: verify `extractReviewerVerdict()` parses correctly and `JudgeOverrodeReviewer` triggers when judge overrides reviewer ITERATE

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)