### PR TITLE
refactor: remove DOCS phase from default phase loop

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -286,7 +286,6 @@ func runSession(cmd *cobra.Command, args []string) error {
 		PlanMaxIterations:      cfg.PhaseLoop.PlanMaxIterations,
 		ImplementMaxIterations: cfg.PhaseLoop.ImplementMaxIterations,
 		ReviewMaxIterations:    cfg.PhaseLoop.ReviewMaxIterations,
-		DocsMaxIterations:      cfg.PhaseLoop.DocsMaxIterations,
 		VerifyMaxIterations:    cfg.PhaseLoop.VerifyMaxIterations,
 		JudgeContextBudget:     cfg.PhaseLoop.JudgeContextBudget,
 		JudgeNoSignalLimit:     cfg.PhaseLoop.JudgeNoSignalLimit,

--- a/internal/cli/run_local.go
+++ b/internal/cli/run_local.go
@@ -151,12 +151,11 @@ func runLocalSession(cmd *cobra.Command, _ []string) error {
 	sessionConfig.ClaudeAuth.AuthMode = claudeAuthMode
 	sessionConfig.ClaudeAuth.AuthJSONBase64 = claudeAuthBase64
 
-	// Enable phase loop (PLAN → IMPLEMENT → DOCS → PR workflow)
+	// Enable phase loop (PLAN → IMPLEMENT → PR workflow)
 	// Phase loop is always enabled - the config just customizes iteration counts
 	sessionConfig.PhaseLoop = &controller.PhaseLoopConfig{
 		PlanMaxIterations:      cfg.PhaseLoop.PlanMaxIterations,
 		ImplementMaxIterations: cfg.PhaseLoop.ImplementMaxIterations,
-		DocsMaxIterations:      cfg.PhaseLoop.DocsMaxIterations,
 		VerifyMaxIterations:    cfg.PhaseLoop.VerifyMaxIterations,
 		JudgeContextBudget:     cfg.PhaseLoop.JudgeContextBudget,
 		JudgeNoSignalLimit:     cfg.PhaseLoop.JudgeNoSignalLimit,

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -102,7 +102,6 @@ type TaskState struct {
 type PhaseLoopConfig struct {
 	PlanMaxIterations      int    `json:"plan_max_iterations,omitempty"`
 	ImplementMaxIterations int    `json:"implement_max_iterations,omitempty"`
-	DocsMaxIterations      int    `json:"docs_max_iterations,omitempty"`
 	VerifyMaxIterations    int    `json:"verify_max_iterations,omitempty"`
 	JudgeContextBudget     int    `json:"judge_context_budget,omitempty"`
 	JudgeNoSignalLimit     int    `json:"judge_no_signal_limit,omitempty"`

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -284,18 +284,16 @@ func TestLoadConfigFromEnv_PhaseLoopConfig(t *testing.T) {
 		wantNil       bool
 		wantPlan      int
 		wantImplement int
-		wantDocs      int
 	}{
 		{
 			name: "phase_loop present with iterations",
 			envValue: `{
 				"id": "test", "repository": "github.com/org/repo",
-				"phase_loop": {"plan_max_iterations": 2, "implement_max_iterations": 8, "docs_max_iterations": 3}
+				"phase_loop": {"plan_max_iterations": 2, "implement_max_iterations": 8}
 			}`,
 			wantNil:       false,
 			wantPlan:      2,
 			wantImplement: 8,
-			wantDocs:      3,
 		},
 		{
 			name: "phase_loop absent",
@@ -346,9 +344,6 @@ func TestLoadConfigFromEnv_PhaseLoopConfig(t *testing.T) {
 			}
 			if tt.wantImplement > 0 && config.PhaseLoop.ImplementMaxIterations != tt.wantImplement {
 				t.Errorf("ImplementMaxIterations = %d, want %d", config.PhaseLoop.ImplementMaxIterations, tt.wantImplement)
-			}
-			if tt.wantDocs > 0 && config.PhaseLoop.DocsMaxIterations != tt.wantDocs {
-				t.Errorf("DocsMaxIterations = %d, want %d", config.PhaseLoop.DocsMaxIterations, tt.wantDocs)
 			}
 		})
 	}

--- a/internal/controller/phase_loop_test.go
+++ b/internal/controller/phase_loop_test.go
@@ -18,8 +18,7 @@ func TestAdvancePhase(t *testing.T) {
 		want    TaskPhase
 	}{
 		{"PLAN advances to IMPLEMENT", PhasePlan, PhaseImplement},
-		{"IMPLEMENT advances to DOCS", PhaseImplement, PhaseDocs},
-		{"DOCS advances to COMPLETE", PhaseDocs, PhaseComplete},
+		{"IMPLEMENT advances to COMPLETE", PhaseImplement, PhaseComplete},
 		{"unknown phase advances to COMPLETE", TaskPhase("UNKNOWN"), PhaseComplete},
 		{"COMPLETE stays COMPLETE", PhaseComplete, PhaseComplete},
 	}
@@ -42,8 +41,7 @@ func TestAdvancePhase_WithAutoMerge(t *testing.T) {
 		want    TaskPhase
 	}{
 		{"PLAN advances to IMPLEMENT", PhasePlan, PhaseImplement},
-		{"IMPLEMENT advances to DOCS", PhaseImplement, PhaseDocs},
-		{"DOCS advances to VERIFY", PhaseDocs, PhaseVerify},
+		{"IMPLEMENT advances to VERIFY", PhaseImplement, PhaseVerify},
 		{"VERIFY advances to COMPLETE", PhaseVerify, PhaseComplete},
 		{"unknown phase advances to COMPLETE", TaskPhase("UNKNOWN"), PhaseComplete},
 	}
@@ -61,7 +59,7 @@ func TestAdvancePhase_WithAutoMerge(t *testing.T) {
 func TestPhaseOrder_WithAutoMerge(t *testing.T) {
 	c := &Controller{config: SessionConfig{AutoMerge: true}}
 	order := c.phaseOrder()
-	expected := []TaskPhase{PhasePlan, PhaseImplement, PhaseDocs, PhaseVerify}
+	expected := []TaskPhase{PhasePlan, PhaseImplement, PhaseVerify}
 	if len(order) != len(expected) {
 		t.Fatalf("phaseOrder() length = %d, want %d", len(order), len(expected))
 	}
@@ -75,7 +73,7 @@ func TestPhaseOrder_WithAutoMerge(t *testing.T) {
 func TestPhaseOrder_WithoutAutoMerge(t *testing.T) {
 	c := &Controller{config: SessionConfig{}}
 	order := c.phaseOrder()
-	expected := []TaskPhase{PhasePlan, PhaseImplement, PhaseDocs}
+	expected := []TaskPhase{PhasePlan, PhaseImplement}
 	if len(order) != len(expected) {
 		t.Fatalf("phaseOrder() length = %d, want %d", len(order), len(expected))
 	}
@@ -99,7 +97,6 @@ func TestPhaseMaxIterations_Defaults(t *testing.T) {
 	}{
 		{PhasePlan, defaultPlanMaxIter},
 		{PhaseImplement, defaultImplementMaxIter},
-		{PhaseDocs, defaultDocsMaxIter},
 		{PhaseVerify, defaultVerifyMaxIter},
 		{TaskPhase("UNKNOWN"), 1},
 	}
@@ -120,7 +117,6 @@ func TestPhaseMaxIterations_CustomConfig(t *testing.T) {
 			PhaseLoop: &PhaseLoopConfig{
 				PlanMaxIterations:      2,
 				ImplementMaxIterations: 10,
-				DocsMaxIterations:      4,
 			},
 		},
 	}
@@ -131,7 +127,6 @@ func TestPhaseMaxIterations_CustomConfig(t *testing.T) {
 	}{
 		{PhasePlan, 2},
 		{PhaseImplement, 10},
-		{PhaseDocs, 4},
 	}
 
 	for _, tt := range tests {
@@ -163,7 +158,6 @@ func TestPhaseMaxIterations_SimplePath(t *testing.T) {
 			PhaseLoop: &PhaseLoopConfig{
 				PlanMaxIterations:      5, // Should be ignored for SIMPLE path
 				ImplementMaxIterations: 10,
-				DocsMaxIterations:      4,
 			},
 		},
 	}
@@ -174,7 +168,6 @@ func TestPhaseMaxIterations_SimplePath(t *testing.T) {
 	}{
 		{PhasePlan, simplePlanMaxIter},
 		{PhaseImplement, simpleImplementMaxIter},
-		{PhaseDocs, simpleDocsMaxIter},
 		{PhaseVerify, simpleVerifyMaxIter},
 		{TaskPhase("UNKNOWN"), 1},
 	}
@@ -213,7 +206,7 @@ func TestIsPhaseLoopEnabled(t *testing.T) {
 func TestIssuePhaseOrder(t *testing.T) {
 	// Verify the expected phase order (REVIEW and PR_CREATION phases removed)
 	// Draft PRs are created during IMPLEMENT and finalized at PhaseComplete
-	expected := []TaskPhase{PhasePlan, PhaseImplement, PhaseDocs}
+	expected := []TaskPhase{PhasePlan, PhaseImplement}
 	if len(issuePhaseOrder) != len(expected) {
 		t.Fatalf("issuePhaseOrder length = %d, want %d", len(issuePhaseOrder), len(expected))
 	}

--- a/prompts/phases/plan_reviewer.md
+++ b/prompts/phases/plan_reviewer.md
@@ -26,6 +26,7 @@ You are reviewing a **plan** produced by an agent. Your role is to provide const
 - **Completeness:** Are necessary steps identified?
 - **Feasibility:** Will this work given the codebase?
 - **Scope:** Does the plan stay within issue requirements?
+- **Documentation:** Does the plan note documentation updates needed alongside code changes?
 
 Plans describe approach, not implementation code. Do not request code snippets, line numbers, or low-level details.
 

--- a/prompts/phases/plan_worker.md
+++ b/prompts/phases/plan_worker.md
@@ -215,6 +215,7 @@ Your plan is output as rich markdown between `AGENTIUM_PLAN_START` / `AGENTIUM_P
 - **Files to Create**: List of new files (if any)
 - **Implementation Steps**: Numbered, detailed steps with code patterns found during exploration
 - **Testing Approach**: How the changes will be verified
+- **Documentation**: Note any documentation that should be updated alongside the code changes
 
 Include enough detail that another agent could follow the plan step-by-step: file paths, function names, code patterns observed, and edge cases to handle.
 


### PR DESCRIPTION
## Summary
- Remove DOCS phase from default `issuePhaseOrder` (`[PLAN, IMPLEMENT]`) and auto-merge order (`[PLAN, IMPLEMENT, VERIFY]`)
- Remove all DOCS-specific iteration constants, config fields, auto-advance logic, and exhaustion handling
- Add one-line documentation reminder to PLAN worker and reviewer prompts to compensate
- Keep `PhaseDocs` constant for backward compatibility with explicit `phases` config

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 9 modified files)
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] Default phase order is `[PLAN, IMPLEMENT]`
- [x] AutoMerge phase order is `[PLAN, IMPLEMENT, VERIFY]`
- [x] Explicit `phases` config including DOCS still compiles

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)