### PR TITLE
Skip closed issues during initSession

### DIFF
--- a/internal/controller/issue_types.go
+++ b/internal/controller/issue_types.go
@@ -21,6 +21,7 @@ type issueDetail struct {
 	Number    int            `json:"number"`
 	Title     string         `json:"title"`
 	Body      string         `json:"body"`
+	State     string         `json:"state"`
 	Labels    []issueLabel   `json:"labels"`
 	Comments  []issueComment `json:"comments"`
 	DependsOn []string       // Parsed dependency issue IDs (populated by buildDependencyGraph)

--- a/internal/controller/issues.go
+++ b/internal/controller/issues.go
@@ -19,7 +19,7 @@ func (c *Controller) fetchIssueDetails(ctx context.Context) []issueDetail {
 		// Use gh CLI to fetch issue
 		cmd := c.execCommand(ctx, "gh", "issue", "view", taskID,
 			"--repo", c.config.Repository,
-			"--json", "number,title,body,labels,comments",
+			"--json", "number,title,body,state,labels,comments",
 		)
 		cmd.Env = c.envWithGitHubToken()
 

--- a/internal/controller/sub_issues.go
+++ b/internal/controller/sub_issues.go
@@ -180,7 +180,7 @@ func (c *Controller) fetchSubIssueDetails(ctx context.Context, issueIDs []string
 
 		cmd := c.execCommand(ctx, "gh", "issue", "view", id,
 			"--repo", c.config.Repository,
-			"--json", "number,title,body,labels",
+			"--json", "number,title,body,state,labels",
 		)
 		cmd.Env = c.envWithGitHubToken()
 


### PR DESCRIPTION
## Summary
- Adds `State` field to `issueDetail` and fetches it via `gh issue view --json`
- Filters out closed issues after fetch in `initSession`, removing them from `issueDetails`, `taskStates`, and `taskQueue`
- Prevents closed issues from reaching the GraphQL sub-issues check that crashes the controller

## Test plan
- [x] `TestFetchIssueDetails_IncludesState` — verifies State field is populated
- [x] `TestFilterClosedIssues` — verifies closed issues removed from all data structures
- [x] `TestFilterClosedIssues_AllClosed` — edge case where all issues are closed
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — no new lint issues

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)