### PR TITLE
fix: retry draft PR creation with hard failure on exhaustion

### DIFF
--- a/internal/controller/draft_pr.go
+++ b/internal/controller/draft_pr.go
@@ -7,9 +7,41 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/andywolf/agentium/internal/handoff"
 )
+
+// createDraftPRWithRetry attempts to create a draft PR with retries and backoff.
+// Returns true if the task was blocked (all retry attempts exhausted).
+func (c *Controller) createDraftPRWithRetry(ctx context.Context, taskID string, state *TaskState, phase TaskPhase, iter int) bool {
+	delays := []time.Duration{0, 2 * time.Second, 4 * time.Second}
+	var prErr error
+	for attempt, delay := range delays {
+		if attempt > 0 {
+			c.logWarning("Draft PR creation failed (retry %d/%d), retrying in %s: %v",
+				attempt, len(delays)-1, delay, prErr)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+			}
+			if ctx.Err() != nil {
+				prErr = ctx.Err()
+				break
+			}
+		}
+		prErr = c.maybeCreateDraftPR(ctx, taskID)
+		if prErr == nil {
+			return false
+		}
+	}
+	c.logError("Draft PR creation failed after %d attempts: %v", len(delays), prErr)
+	state.Phase = PhaseBlocked
+	state.ControllerOverrode = true
+	c.postPhaseComment(ctx, phase, iter, RoleController,
+		fmt.Sprintf("BLOCKED: draft PR creation failed after %d attempts: %v — task requires human intervention.", len(delays), prErr))
+	return true
+}
 
 // maybeCreateDraftPR ensures a draft PR exists for the current branch.
 // It first checks if a PR already exists (from worker, previous run, etc.),

--- a/internal/controller/draft_pr_test.go
+++ b/internal/controller/draft_pr_test.go
@@ -238,6 +238,96 @@ func TestMaybeCreateDraftPR_SkipsMismatchedBranch(t *testing.T) {
 	}
 }
 
+func TestCreateDraftPRWithRetry_BlocksOnExhaustion(t *testing.T) {
+	taskID := "issue:123"
+	state := &TaskState{
+		ID:             "123",
+		Type:           "issue",
+		Phase:          PhaseImplement,
+		DraftPRCreated: false,
+	}
+	c := &Controller{
+		taskStates: map[string]*TaskState{taskID: state},
+		logger:     newTestLogger(),
+		workDir:    "/nonexistent/path/that/does/not/exist",
+	}
+
+	// maybeCreateDraftPR will fail because workDir doesn't exist,
+	// causing branch detection to fail on every attempt.
+	blocked := c.createDraftPRWithRetry(context.Background(), taskID, state, PhaseImplement, 1)
+
+	if !blocked {
+		t.Fatal("expected createDraftPRWithRetry to return blocked=true after exhausting retries")
+	}
+	if state.Phase != PhaseBlocked {
+		t.Errorf("state.Phase = %q, want %q", state.Phase, PhaseBlocked)
+	}
+	if !state.ControllerOverrode {
+		t.Error("expected state.ControllerOverrode to be true")
+	}
+	if state.DraftPRCreated {
+		t.Error("expected state.DraftPRCreated to remain false")
+	}
+}
+
+func TestCreateDraftPRWithRetry_SucceedsWhenAlreadyCreated(t *testing.T) {
+	taskID := "issue:456"
+	state := &TaskState{
+		ID:             "456",
+		Type:           "issue",
+		Phase:          PhaseImplement,
+		DraftPRCreated: true, // Already created
+	}
+	c := &Controller{
+		taskStates: map[string]*TaskState{taskID: state},
+		logger:     newTestLogger(),
+	}
+
+	// maybeCreateDraftPR returns nil immediately when DraftPRCreated is true,
+	// so the retry loop should succeed on the first attempt.
+	blocked := c.createDraftPRWithRetry(context.Background(), taskID, state, PhaseImplement, 1)
+
+	if blocked {
+		t.Fatal("expected createDraftPRWithRetry to return blocked=false when PR already created")
+	}
+	if state.Phase != PhaseImplement {
+		t.Errorf("state.Phase = %q, want %q", state.Phase, PhaseImplement)
+	}
+	if state.ControllerOverrode {
+		t.Error("expected state.ControllerOverrode to remain false")
+	}
+}
+
+func TestCreateDraftPRWithRetry_RespectsContextCancellation(t *testing.T) {
+	taskID := "issue:789"
+	state := &TaskState{
+		ID:             "789",
+		Type:           "issue",
+		Phase:          PhaseImplement,
+		DraftPRCreated: false,
+	}
+	c := &Controller{
+		taskStates: map[string]*TaskState{taskID: state},
+		logger:     newTestLogger(),
+	}
+
+	// Cancel context before calling — the retry loop should stop early.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	blocked := c.createDraftPRWithRetry(ctx, taskID, state, PhaseImplement, 1)
+
+	if !blocked {
+		t.Fatal("expected createDraftPRWithRetry to return blocked=true on cancelled context")
+	}
+	if state.Phase != PhaseBlocked {
+		t.Errorf("state.Phase = %q, want %q", state.Phase, PhaseBlocked)
+	}
+	if !state.ControllerOverrode {
+		t.Error("expected state.ControllerOverrode to be true")
+	}
+}
+
 func TestTaskState_NOMERGEConditions(t *testing.T) {
 	// Verify both ControllerOverrode and JudgeOverrodeReviewer trigger NOMERGE
 	tests := []struct {

--- a/internal/controller/phase_loop.go
+++ b/internal/controller/phase_loop.go
@@ -494,32 +494,7 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 			// Create draft PR after first IMPLEMENT iteration with commits.
 			// Retry with backoff — a task must not "complete" without a PR.
 			if plc.currentPhase == PhaseImplement && !state.DraftPRCreated {
-				delays := []time.Duration{0, 2 * time.Second, 4 * time.Second}
-				var prErr error
-				for attempt, delay := range delays {
-					if attempt > 0 {
-						c.logWarning("Draft PR creation failed (attempt %d/%d), retrying in %s: %v",
-							attempt, len(delays), delay, prErr)
-						select {
-						case <-time.After(delay):
-						case <-ctx.Done():
-						}
-						if ctx.Err() != nil {
-							prErr = ctx.Err()
-							break
-						}
-					}
-					prErr = c.maybeCreateDraftPR(ctx, taskID)
-					if prErr == nil {
-						break
-					}
-				}
-				if prErr != nil {
-					c.logError("Draft PR creation failed after %d attempts: %v", len(delays), prErr)
-					state.Phase = PhaseBlocked
-					state.ControllerOverrode = true
-					c.postPhaseComment(ctx, plc.currentPhase, iter, RoleController,
-						fmt.Sprintf("BLOCKED: draft PR creation failed after %d attempts: %v — task requires human intervention.", len(delays), prErr))
+				if blocked := c.createDraftPRWithRetry(ctx, taskID, state, plc.currentPhase, iter); blocked {
 					return nil
 				}
 			}


### PR DESCRIPTION
## Summary

- Add retry loop (3 attempts, 0s/2s/4s backoff) to `maybeCreateDraftPR` in the phase loop — previously failures were silently swallowed as warnings, allowing tasks to "complete" without a PR
- On exhaustion, mark task as `PhaseBlocked` with `ControllerOverrode = true` and post a `BLOCKED` phase comment requiring human intervention
- Pass GitHub token env to `git ls-remote` in `ensureBranchPushed` so it can authenticate with private repos
- Extract retry logic into `createDraftPRWithRetry()` helper for testability
- Fix off-by-one in retry log message: use "retry N/M" terminology instead of ambiguous "attempt N/M"
- Add tests for retry exhaustion → `PhaseBlocked`, success when PR already created, and context cancellation

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes
- [x] `golangci-lint run ./...` — no new lint issues
- [x] `TestCreateDraftPRWithRetry_BlocksOnExhaustion` — retries exhaust, state becomes `PhaseBlocked` with `ControllerOverrode`
- [x] `TestCreateDraftPRWithRetry_SucceedsWhenAlreadyCreated` — early exit when PR exists
- [x] `TestCreateDraftPRWithRetry_RespectsContextCancellation` — stops on cancelled context

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)