### PR TITLE
fix: use shared GCP firewall rule to prevent quota exhaustion

### DIFF
--- a/docs/cloud-setup/gcp.md
+++ b/docs/cloud-setup/gcp.md
@@ -282,7 +282,14 @@ gcloud services enable compute.googleapis.com secretmanager.googleapis.com
 
 ### "Quota exceeded"
 
-Check your project quotas:
+Agentium uses a single shared firewall rule (`agentium-allow-egress`) that is created automatically on first use and persists across sessions. If you upgraded from an older version, orphaned per-session firewall rules (`agentium-allow-egress-<prefix>`) may be consuming the `FIREWALLS` quota. Clean them up with:
+
+```bash
+gcloud compute firewall-rules list --filter="name~agentium-allow-egress-" --format="value(name)" \
+  | xargs -I {} gcloud compute firewall-rules delete {} --quiet
+```
+
+For other quota issues, check your project quotas:
 
 ```bash
 gcloud compute project-info describe --project YOUR_PROJECT_ID

--- a/internal/provisioner/gcp.go
+++ b/internal/provisioner/gcp.go
@@ -15,6 +15,15 @@ import (
 	"github.com/andywolf/agentium/terraform"
 )
 
+const (
+	// sharedFirewallRuleName is the name of the single shared egress firewall
+	// rule used by all Agentium sessions. Created once on first use.
+	sharedFirewallRuleName = "agentium-allow-egress"
+
+	// defaultNetwork is the GCP VPC network used when none is configured.
+	defaultNetwork = "default"
+)
+
 // GCPProvisioner implements Provisioner for Google Cloud Platform
 type GCPProvisioner struct {
 	verbose           bool
@@ -54,6 +63,56 @@ func (p *GCPProvisioner) setCredentialEnv(cmd *exec.Cmd) {
 		"GOOGLE_APPLICATION_CREDENTIALS="+p.serviceAccountKey,
 		"CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="+p.serviceAccountKey,
 	)
+}
+
+// ensureFirewallRule creates the shared egress firewall rule if it does not
+// already exist. The rule is shared across all Agentium sessions and is never
+// deleted during session teardown.
+func (p *GCPProvisioner) ensureFirewallRule(ctx context.Context) error {
+	network := defaultNetwork
+
+	// Check if the rule already exists
+	descArgs := []string{"compute", "firewall-rules", "describe", sharedFirewallRuleName, "--format=value(name)"}
+	if p.project != "" {
+		descArgs = append(descArgs, "--project="+p.project)
+	}
+	descCmd := exec.CommandContext(ctx, "gcloud", descArgs...)
+	p.setCredentialEnv(descCmd)
+	if err := descCmd.Run(); err == nil {
+		// Rule already exists
+		return nil
+	}
+
+	// Rule doesn't exist — create it
+	createArgs := []string{
+		"compute", "firewall-rules", "create", sharedFirewallRuleName,
+		"--direction=EGRESS",
+		"--action=ALLOW",
+		"--rules=tcp:443,tcp:80,tcp:22",
+		"--target-tags=agentium",
+		"--network=" + network,
+		"--quiet",
+	}
+	if p.project != "" {
+		createArgs = append(createArgs, "--project="+p.project)
+	}
+	createCmd := exec.CommandContext(ctx, "gcloud", createArgs...)
+	p.setCredentialEnv(createCmd)
+	output, err := createCmd.CombinedOutput()
+	if err != nil {
+		// Handle race condition: another session may have created the rule concurrently
+		if isAlreadyExistsError(string(output)) {
+			return nil
+		}
+		return fmt.Errorf("failed to create shared firewall rule: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// isAlreadyExistsError checks if gcloud command output indicates a resource already exists.
+func isAlreadyExistsError(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "already exists")
 }
 
 // Provision creates a new GCP VM for an agent session
@@ -132,6 +191,11 @@ max_run_duration   = "%s"
 	// Copy terraform files to work directory
 	if err = p.copyTerraformFiles(workDir); err != nil {
 		return nil, fmt.Errorf("failed to copy terraform files: %w", err)
+	}
+
+	// Ensure the shared egress firewall rule exists (created once, never deleted)
+	if err = p.ensureFirewallRule(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure firewall rule: %w", err)
 	}
 
 	// Run terraform init
@@ -608,13 +672,7 @@ func (p *GCPProvisioner) destroyFallback(ctx context.Context, sessionID string) 
 		errors = append(errors, fmt.Sprintf("instance: %v", err))
 	}
 
-	// 2. Delete the firewall rule
-	firewallName := fmt.Sprintf("agentium-allow-egress-%s", prefix)
-	if err := p.deleteFirewallRule(ctx, firewallName); err != nil {
-		errors = append(errors, fmt.Sprintf("firewall: %v", err))
-	}
-
-	// 3. Remove IAM bindings for the service account
+	// 2. Remove IAM bindings for the service account
 	iamRoles := []string{
 		"roles/secretmanager.secretAccessor",
 		"roles/logging.logWriter",
@@ -626,7 +684,7 @@ func (p *GCPProvisioner) destroyFallback(ctx context.Context, sessionID string) 
 		}
 	}
 
-	// 4. Delete the service account
+	// 3. Delete the service account
 	if err := p.deleteServiceAccount(ctx, saEmail); err != nil {
 		errors = append(errors, fmt.Sprintf("service-account: %v", err))
 	}
@@ -665,31 +723,6 @@ func (p *GCPProvisioner) deleteInstance(ctx context.Context, instanceName string
 			return nil
 		}
 		return fmt.Errorf("failed to delete instance %s: %w", instanceName, err)
-	}
-	return nil
-}
-
-// deleteFirewallRule deletes a GCP firewall rule by name.
-func (p *GCPProvisioner) deleteFirewallRule(ctx context.Context, ruleName string) error {
-	args := []string{"compute", "firewall-rules", "delete", ruleName, "--quiet"}
-	if p.project != "" {
-		args = append(args, "--project="+p.project)
-	}
-
-	cmd := exec.CommandContext(ctx, "gcloud", args...)
-	p.setCredentialEnv(cmd)
-	output, err := cmd.CombinedOutput()
-	if p.verbose && len(output) > 0 {
-		fmt.Fprintf(os.Stderr, "%s", output)
-	}
-	if err != nil {
-		if isNotFoundError(string(output)) {
-			if p.verbose {
-				fmt.Fprintf(os.Stderr, "firewall rule %s already deleted\n", ruleName)
-			}
-			return nil
-		}
-		return fmt.Errorf("failed to delete firewall rule %s: %w", ruleName, err)
 	}
 	return nil
 }

--- a/internal/provisioner/gcp_destroy_test.go
+++ b/internal/provisioner/gcp_destroy_test.go
@@ -112,32 +112,28 @@ func TestDestroyFallbackResourceNaming(t *testing.T) {
 	// This test verifies that the resource naming in the fallback path
 	// matches the Terraform naming convention.
 	tests := []struct {
-		name         string
-		sessionID    string
-		project      string
-		wantSAEmail  string
-		wantFirewall string
+		name        string
+		sessionID   string
+		project     string
+		wantSAEmail string
 	}{
 		{
-			name:         "standard session ID",
-			sessionID:    "agentium-abc123def456ghi789",
-			project:      "my-project",
-			wantSAEmail:  "agentium-agentium-abc123def45@my-project.iam.gserviceaccount.com",
-			wantFirewall: "agentium-allow-egress-agentium-abc123def45",
+			name:        "standard session ID",
+			sessionID:   "agentium-abc123def456ghi789",
+			project:     "my-project",
+			wantSAEmail: "agentium-agentium-abc123def45@my-project.iam.gserviceaccount.com",
 		},
 		{
-			name:         "short session ID",
-			sessionID:    "test-session",
-			project:      "test-proj",
-			wantSAEmail:  "agentium-test-session@test-proj.iam.gserviceaccount.com",
-			wantFirewall: "agentium-allow-egress-test-session",
+			name:        "short session ID",
+			sessionID:   "test-session",
+			project:     "test-proj",
+			wantSAEmail: "agentium-test-session@test-proj.iam.gserviceaccount.com",
 		},
 		{
-			name:         "exactly 20 char session ID",
-			sessionID:    "12345678901234567890",
-			project:      "proj",
-			wantSAEmail:  "agentium-12345678901234567890@proj.iam.gserviceaccount.com",
-			wantFirewall: "agentium-allow-egress-12345678901234567890",
+			name:        "exactly 20 char session ID",
+			sessionID:   "12345678901234567890",
+			project:     "proj",
+			wantSAEmail: "agentium-12345678901234567890@proj.iam.gserviceaccount.com",
 		},
 	}
 
@@ -151,12 +147,48 @@ func TestDestroyFallbackResourceNaming(t *testing.T) {
 			if saEmail != tt.wantSAEmail {
 				t.Errorf("service account email = %q, want %q", saEmail, tt.wantSAEmail)
 			}
+		})
+	}
+}
 
-			// Verify firewall rule name matches Terraform convention:
-			// name = "agentium-allow-egress-${substr(var.session_id, 0, 20)}"
-			firewallName := "agentium-allow-egress-" + prefix
-			if firewallName != tt.wantFirewall {
-				t.Errorf("firewall rule name = %q, want %q", firewallName, tt.wantFirewall)
+func TestIsAlreadyExistsError(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "resource already exists",
+			output: "ERROR: (gcloud.compute.firewall-rules.create) Could not create firewall rule: The resource 'projects/my-project/global/firewalls/agentium-allow-egress' already exists",
+			want:   true,
+		},
+		{
+			name:   "already exists lowercase",
+			output: "the resource already exists in project",
+			want:   true,
+		},
+		{
+			name:   "not found error",
+			output: "ERROR: The resource was not found",
+			want:   false,
+		},
+		{
+			name:   "permission denied error",
+			output: "ERROR: Permission denied",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAlreadyExistsError(tt.output)
+			if got != tt.want {
+				t.Errorf("isAlreadyExistsError(%q) = %v, want %v", tt.output, got, tt.want)
 			}
 		})
 	}

--- a/terraform/modules/vm/gcp/main.tf
+++ b/terraform/modules/vm/gcp/main.tf
@@ -371,25 +371,6 @@ resource "google_compute_instance" "agentium" {
     google_service_account_iam_member.self_user,
   ]
 }
-
-# Firewall rule to allow outbound traffic
-resource "google_compute_firewall" "agentium_egress" {
-  name    = "agentium-allow-egress-${substr(var.session_id, 0, 20)}"
-  network = var.network
-  project = var.project_id
-
-  direction = "EGRESS"
-
-  allow {
-    protocol = "tcp"
-    ports    = ["443", "80", "22"]
-  }
-
-  target_tags = ["agentium"]
-
-  depends_on = [google_project_service.compute]
-}
-
 output "instance_id" {
   description = "The instance ID"
   value       = google_compute_instance.agentium.name


### PR DESCRIPTION
## Summary

- Replace per-session GCP firewall rules (`agentium-allow-egress-<prefix>`) with a single shared rule (`agentium-allow-egress`) created once via `gcloud` on first use
- Prevents the `FIREWALLS` quota (100/project) from being exhausted when orphaned rules accumulate
- Removes firewall deletion from session teardown since the rule is shared and persistent

## Changes

- **`terraform/modules/vm/gcp/main.tf`**: Remove `google_compute_firewall` resource
- **`internal/provisioner/gcp.go`**: Add `ensureFirewallRule()` with describe-then-create pattern and race condition handling; remove firewall deletion from `destroyFallback()`; remove unused `deleteFirewallRule()`
- **`internal/provisioner/gcp_destroy_test.go`**: Remove firewall assertions from `TestDestroyFallbackResourceNaming`; add `TestIsAlreadyExistsError`
- **`docs/cloud-setup/gcp.md`**: Update "Quota exceeded" section with migration cleanup command

## Migration

Old per-session rules coexist safely (GCP ALLOW rules are additive). Orphaned rules can be cleaned up with:
```bash
gcloud compute firewall-rules list --filter="name~agentium-allow-egress-" --format="value(name)" \
  | xargs -I {} gcloud compute firewall-rules delete {} --quiet
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/provisioner/...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] Manual: run `agentium run` and verify `agentium-allow-egress` rule is created
- [ ] Manual: run a second session and verify no duplicate rule creation
- [ ] Manual: `agentium destroy` does not delete the shared rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)