### PR TITLE
fix: add --condition=None to unconditional IAM bindings

### DIFF
--- a/internal/provisioner/gcp.go
+++ b/internal/provisioner/gcp.go
@@ -161,6 +161,7 @@ func (p *GCPProvisioner) ensureServiceAccount(ctx context.Context) (string, erro
 			"projects", "add-iam-policy-binding", p.project,
 			"--member=" + member,
 			"--role=" + role,
+			"--condition=None",
 			"--quiet",
 		}
 		cmd := exec.CommandContext(ctx, "gcloud", args...)
@@ -175,6 +176,7 @@ func (p *GCPProvisioner) ensureServiceAccount(ctx context.Context) (string, erro
 		"iam", "service-accounts", "add-iam-policy-binding", saEmail,
 		"--member=" + member,
 		"--role=roles/iam.serviceAccountUser",
+		"--condition=None",
 		"--quiet",
 	}
 	if p.project != "" {


### PR DESCRIPTION
## Summary
- Add `--condition=None` to unconditional IAM policy bindings (static roles and self-user)
- Fixes `gcloud.projects.add-iam-policy-binding` error when project IAM policy already contains conditional bindings (from per-instance compute admin conditions)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Manual: run `agentium launch` and verify shared SA creation succeeds

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)