### PR TITLE
chore: slim CI builds and only build containers on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
       contents: read
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
             goarch: arm64
     steps:
       - uses: actions/checkout@v6
@@ -72,17 +72,13 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          ext=""
-          if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
           LDFLAGS="-X github.com/andywolf/agentium/internal/version.Commit=${{ github.sha }}"
-          go build -ldflags="${LDFLAGS}" -o agentium-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/agentium
+          go build -ldflags="${LDFLAGS}" -o agentium-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/agentium
 
       - name: Build controller
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          ext=""
-          if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
           LDFLAGS="-X github.com/andywolf/agentium/internal/version.Commit=${{ github.sha }}"
-          go build -ldflags="${LDFLAGS}" -o controller-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/controller
+          go build -ldflags="${LDFLAGS}" -o controller-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/controller

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,15 +1,6 @@
 name: Build and Push Docker Images
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/docker.yml"
-      - "docker/**"
-      - "cmd/**"
-      - "internal/**"
-      - "go.mod"
-      - "go.sum"
   schedule:
     # Rebuild weekly to pick up new agent CLI versions (Claude Code, Codex)
     - cron: "0 6 * * 1" # Every Monday at 6am UTC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
             goarch: arm64
     steps:
       - uses: actions/checkout@v6
@@ -37,8 +37,6 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          ext=""
-          if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
           mkdir -p dist
 
           VERSION="${{ github.ref_name }}"
@@ -50,9 +48,9 @@ jobs:
             -X github.com/andywolf/agentium/internal/version.BuildDate=${BUILD_DATE}"
 
           go build -ldflags="${LDFLAGS}" \
-            -o dist/agentium-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/agentium
+            -o dist/agentium-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/agentium
           go build -ldflags="${LDFLAGS}" \
-            -o dist/controller-${{ matrix.goos }}-${{ matrix.goarch }}${ext} ./cmd/controller
+            -o dist/controller-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/controller
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- Removed push-to-main trigger from `docker.yml` — containers now only build on releases (via `release.yml`), weekly schedule (for new agent CLI versions), or manual dispatch
- Trimmed binary build matrix from 5 platform combos to 2: `linux/amd64` (GCP VMs) and `darwin/arm64` (macOS M2 CLI)
- Removed Windows `.exe` build logic

## Test plan
- [ ] Verify CI passes on this PR (lint, test, build with trimmed matrix)
- [ ] Confirm docker.yml no longer triggers on push to main after merge
- [ ] Next release-please tag should produce only 2 binary artifacts + containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)