### PR TITLE
Pass assistant text instead of raw output to eval prompts

### DIFF
--- a/internal/controller/phase_loop.go
+++ b/internal/controller/phase_loop.go
@@ -18,7 +18,7 @@ import (
 //
 //	phase_loop.go          — initializes/resets all fields in the outer and inner loops
 //	phase_loop_tracing.go  — manages tracing fields (traceCtx … traceStatus)
-//	phase_loop_iteration.go — writes per-iteration output (phaseOutput, commentContent)
+//	phase_loop_iteration.go — writes per-iteration output (phaseOutput, evalOutput, commentContent)
 //	phase_loop_phases.go   — writes advanced, maxIter (complexity assessment), and state fields
 //	phase_loop_eval.go     — writes advanced, noSignalCount, traceStatus, and state fields
 type phaseLoopContext struct {
@@ -41,7 +41,8 @@ type phaseLoopContext struct {
 	noSignalCount int  // updated by applyJudgePostProcessing (phase_loop_eval.go)
 
 	// Per-iteration output (reset each iteration in runPhaseLoop)
-	phaseOutput    string // written by runWorkerIteration (phase_loop_iteration.go)
+	phaseOutput    string // written by runWorkerIteration (phase_loop_iteration.go) — full RawTextContent for signal parsing
+	evalOutput     string // written by runWorkerIteration (phase_loop_iteration.go) — assistant text only, for reviewer/judge/complexity prompts
 	commentContent string // written by runWorkerIteration (phase_loop_iteration.go)
 }
 
@@ -67,9 +68,10 @@ const (
 	simpleVerifyMaxIter    = 2
 )
 
-// defaultJudgeContextBudget is the default max characters of phase output sent to the judge.
-// Increased from 8000 to 16000 to avoid truncating PLAN phase output that the judge/reviewer
-// need to see in full for correct ADVANCE/ITERATE decisions.
+// defaultJudgeContextBudget is the default max characters of eval output (assistant text)
+// sent to the judge/reviewer/complexity prompts. Now that evalOutput excludes tool results
+// (file contents, diffs, command output), this budget applies to the much smaller assistant
+// narration rather than the full RawTextContent.
 const defaultJudgeContextBudget = 16000
 
 // Skip condition constants for reviewer/judge conditional skipping.
@@ -462,6 +464,7 @@ func (c *Controller) runPhaseLoop(ctx context.Context) error {
 
 			// Reset per-iteration state
 			plc.phaseOutput = ""
+			plc.evalOutput = ""
 			plc.commentContent = ""
 
 			if err := c.runWorkerIteration(ctx, plc, iter); err != nil {

--- a/internal/controller/phase_loop_eval.go
+++ b/internal/controller/phase_loop_eval.go
@@ -179,7 +179,7 @@ func (c *Controller) runReviewJudgePipeline(ctx context.Context, plc *phaseLoopC
 	// Run reviewer
 	reviewResult, reviewErr := c.runReviewer(ctx, reviewRunParams{
 		CompletedPhase:          plc.currentPhase,
-		PhaseOutput:             plc.phaseOutput,
+		PhaseOutput:             plc.evalOutput,
 		Iteration:               iter,
 		MaxIterations:           plc.maxIter,
 		PreviousFeedback:        previousFeedback,
@@ -231,7 +231,7 @@ func (c *Controller) runReviewJudgePipeline(ctx context.Context, plc *phaseLoopC
 	// Run judge
 	judgeResult, err := c.runJudge(ctx, judgeRunParams{
 		CompletedPhase:  plc.currentPhase,
-		PhaseOutput:     plc.phaseOutput,
+		PhaseOutput:     plc.evalOutput,
 		ReviewFeedback:  reviewResult.Feedback,
 		Iteration:       iter,
 		MaxIterations:   plc.maxIter,

--- a/internal/controller/phase_loop_iteration.go
+++ b/internal/controller/phase_loop_iteration.go
@@ -62,10 +62,17 @@ func (c *Controller) runWorkerIteration(ctx context.Context, plc *phaseLoopConte
 		EndTime:      result.EndTime,
 	})
 
-	// Full output for internal processing (handoff parsing, judge context)
+	// Full output for internal processing (handoff parsing, plan markers, signal detection)
 	plc.phaseOutput = result.RawTextContent
 	if plc.phaseOutput == "" {
 		plc.phaseOutput = result.Summary
+	}
+
+	// Assistant-only text for reviewer/judge/complexity prompts (excludes tool results
+	// like file contents, diffs, and command output that inflate the context).
+	plc.evalOutput = result.AssistantText
+	if plc.evalOutput == "" {
+		plc.evalOutput = plc.phaseOutput
 	}
 
 	// Filtered output for GitHub comments (assistant text only, no tool results)
@@ -84,10 +91,10 @@ func (c *Controller) runWorkerIteration(ctx context.Context, plc *phaseLoopConte
 // writes the plan file for the PLAN phase. Returns an error if the plan file
 // write fails — callers should treat this as a fatal condition (BLOCKED).
 func (c *Controller) processWorkerHandoff(plc *phaseLoopContext, iter int) error {
-	// Warn if phase output exceeds judge context budget
-	if plc.phaseOutput != "" && len(plc.phaseOutput) > c.judgeContextBudget() {
-		c.logWarning("Phase %s output (%d chars) exceeds judge context budget (%d chars) — judge/reviewer will see truncated output",
-			plc.currentPhase, len(plc.phaseOutput), c.judgeContextBudget())
+	// Warn if eval output (assistant text for reviewer/judge) exceeds judge context budget
+	if plc.evalOutput != "" && len(plc.evalOutput) > c.judgeContextBudget() {
+		c.logWarning("Phase %s eval output (%d chars) exceeds judge context budget (%d chars) — judge/reviewer will see truncated output",
+			plc.currentPhase, len(plc.evalOutput), c.judgeContextBudget())
 	}
 
 	// Parse and store handoff output if enabled

--- a/internal/controller/phase_loop_phases.go
+++ b/internal/controller/phase_loop_phases.go
@@ -72,7 +72,7 @@ func (c *Controller) handleComplexityAssessment(ctx context.Context, plc *phaseL
 		return false
 	}
 	complexityResult, complexityErr := c.runComplexityAssessor(ctx, complexityRunParams{
-		PlanOutput:    plc.phaseOutput,
+		PlanOutput:    plc.evalOutput,
 		Iteration:     iter,
 		MaxIterations: plc.maxIter,
 	})


### PR DESCRIPTION
## Summary

- Split `phaseOutput` into `phaseOutput` (full `RawTextContent` for signal parsing) and `evalOutput` (`AssistantText` only for reviewer/judge/complexity prompts)
- Eliminates truncation warnings where 57K+ char IMPLEMENT output was being tail-truncated to fit the 16K judge context budget
- Eval prompts now receive the agent's narration without tool noise (file contents, diffs, command output)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/...` passes
- [ ] Verify in a live session that judge/reviewer truncation warnings no longer appear for typical IMPLEMENT phases
- [ ] Confirm judge/reviewer decisions remain correct with assistant-text-only context

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)